### PR TITLE
Upgrade jetty for security issue

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -17,7 +17,7 @@
                  [metosin/ring-http-response "0.9.1" :exclusions [ring/ring-core]]
                  [org.apache.commons/commons-csv "1.8"]
                  [commons-io/commons-io "2.6"]
-                 [info.sunng/ring-jetty9-adapter "0.12.8"]
+                 [info.sunng/ring-jetty9-adapter "0.13.0"]
                  [com.stuartsierra/component "1.0.0"]
                  [hikari-cp "2.12.0"]
                  [seancorfield/next.jdbc "1.0.424"]


### PR DESCRIPTION
For [CVE-2019-17638](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-17638)

Changes
- `info.sunng/ring-jetty9-adapter` 0.12.8->0.13.0
https://github.com/sunng87/ring-jetty9-adapter/compare/0.12.8...0.13.0
