### PR TITLE
Fix to check whether body string is nil or not

### DIFF
--- a/src/toyokumo/commons/email/send_grid.clj
+++ b/src/toyokumo/commons/email/send_grid.clj
@@ -35,7 +35,7 @@
   [response]
   (if (and (map? response)
            (= (get-in response [:headers "Content-Type"]) "application/json"))
-    (update response :body #(tc.json/json-decode json-mapper %))
+    (update response :body #(when (seq %) (tc.json/json-decode json-mapper %)))
     response))
 
 (defn- request*


### PR DESCRIPTION
SendGrid often returns a response which body is empty.
So I've changed to check whether body string is nil or not.