### PR TITLE
Bump jakarta mail to ver 2.0.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -24,7 +24,7 @@
                  [metosin/jsonista "0.2.6"]
                  [com.taoensso/carmine "2.19.1"]
                  [org.clojure/tools.logging "1.1.0"]
-                 [com.sun.mail/jakarta.mail "1.6.5"]
+                 [com.sun.mail/jakarta.mail "2.0.0"]
                  [clj-http "3.10.1"]
                  [diehard "0.10.0"]]
   :source-paths ["src" "src-cljs" "src-cljc"]

--- a/src/toyokumo/commons/email.clj
+++ b/src/toyokumo/commons/email.clj
@@ -3,7 +3,7 @@
    [clojure.string :as str]
    [schema.core :as s])
   (:import
-   (javax.mail.internet
+   (jakarta.mail.internet
     AddressException
     InternetAddress)))
 


### PR DESCRIPTION
https://github.com/eclipse-ee4j/mail/releases/tag/2.0.0-RELEASE
> The 2.0.0 release is the first release of the Jakarta Mail project using jakarta.mail.* package namespace. There are no bug fixes nor enhancements from previous release.
Applications should be able to switch to this new version fairly easily by just changing all imports that use javax.mail.* to instead use jakarta.mail.*.

Only bumped version and replaced namespaces.