### PR TITLE
Add :tag to scm section in pom.xml

### DIFF
--- a/build.clj
+++ b/build.clj
@@ -10,7 +10,8 @@
 (def ^:private jar-file "target/toyokumo-commons.jar")
 (def ^:private scm {:connection "scm:git:git://github.com/toyokumo/toyokumo-commons.git"
                     :developerConnection "scm:git:ssh://git@github.com/toyokumo/toyokumo-commons.git"
-                    :url "https://github.com/toyokumo/toyokumo-commons"})
+                    :url "https://github.com/toyokumo/toyokumo-commons"
+                    :tag version})
 
 (defn pom
   [_]


### PR DESCRIPTION
cljdoc requires `tag` value in pom.xml's `scm` section, but I missed it.
https://github.com/cljdoc/cljdoc/blob/master/doc/userguide/for-library-authors.adoc#git-sources