### PR TITLE
Feature/cljdoc to work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 # Change Log
 
 ## [Unreleased]
+### Breaking
 - Remove deprecated codes for PostgreSQL. Use `toyokumo.commons.db.postgresql` and `toyokumo.commons.db.extension.postgresql`
+
+### Fixed
+- Fix cljdoc to be able to generate documents correctly.
 
 ## 0.3.139
 ### Added

--- a/doc/cljdoc.edn
+++ b/doc/cljdoc.edn
@@ -1,0 +1,4 @@
+{:cljdoc.doc/tree
+ [["Readme" {:file "README.md"}]
+  ["Changes" {:file "CHANGELOG.md"}]
+  ["PostgreSQL" {:file "doc/postgresql.md"}]]}

--- a/doc/postgresql.md
+++ b/doc/postgresql.md
@@ -1,0 +1,21 @@
+# PostgreSQL-specific features
+
+To use following features, `org.postgresql/postgresql` is required.
+
+## toyokumo.commons.db.extension.postgresql
+Provides extensions of reading objects that are in PostgreSQL from the `java.sql.ResultSet` or setting SQL parameters in statement objects.
+
+See also [next.jdbc.date-time](https://github.com/seancorfield/next-jdbc/blob/develop/src/next/jdbc/date_time.clj), which provides default datetime extensions.
+
+| Function/Var | Description |
+| ------------ | ----------- |
+| set-json-as-parameter | Make Clojure map jsonb in PreparedStatement |
+| read-json | Read jsonb or json as Clojure data |
+
+## toyokumo.commons.db.postgresql
+
+| Function/Var | Description |
+| ------------ | ----------- |
+| \*format-table\* | How to format table name |
+| \*format-column\* | How to format column name |
+| copy-in | Use `COPY FROM STDIN` for very fast copying from a Reader into a database table |

--- a/src/toyokumo/commons/db/extension/postgresql.clj
+++ b/src/toyokumo/commons/db/extension/postgresql.clj
@@ -1,4 +1,4 @@
-(ns toyokumo.commons.db.extension.postgresql
+(ns ^:no-doc toyokumo.commons.db.extension.postgresql
   "Provides extensions of reading objects that are in PostgreSQL from the `java.sql.ResultSet`
   or setting SQL parameters in statement objects.
   See also next.jdbc.date-time, which provides default datetime extensions."

--- a/src/toyokumo/commons/db/postgresql.clj
+++ b/src/toyokumo/commons/db/postgresql.clj
@@ -1,4 +1,4 @@
-(ns toyokumo.commons.db.postgresql
+(ns ^:no-doc toyokumo.commons.db.postgresql
   (:require
    [camel-snake-kebab.core :as csk]
    [clojure.java.io :as io]


### PR DESCRIPTION
Currently building documentations are failed because of missing `org.postgresql.*` classes.
https://app.circleci.com/pipelines/github/cljdoc/builder/31168/workflows/d51352ac-29a6-4dee-b01d-6005ea12c577/jobs/47542

I  updated `toyokumo.commons.db.postgresql` and `toyokumo.commons.db.extension.postgresql` namespaces to skip building documents for now, and added separate documents for PostgreSQL-specific features.

This is a tentative solution for cljdoc.