### PR TITLE
Fix ring.response/attachment to handle space correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Changed
+- Exclude `slf4j-api` from dependencies.
+
+### Fixed
+- Fix `toyokumo.commons.ring.response/attachment` to handle filenames containing spaces correctly.
+
 ## 0.3.151
 ### Breaking
 - Remove deprecated codes for PostgreSQL. Use `toyokumo.commons.db.postgresql` and `toyokumo.commons.db.extension.postgresql`

--- a/deps.edn
+++ b/deps.edn
@@ -11,7 +11,7 @@
         commons-io/commons-io {:mvn/version "2.11.0"}
         info.sunng/ring-jetty9-adapter {:mvn/version "0.17.6"}
         com.stuartsierra/component {:mvn/version "1.1.0"}
-        hikari-cp/hikari-cp {:mvn/version "2.14.0"}
+        hikari-cp/hikari-cp {:mvn/version "2.14.0" :exclusions [org.slf4j/slf4j-api]}
         com.github.seancorfield/next.jdbc {:mvn/version "1.2.772"}
         metosin/jsonista {:mvn/version "0.3.5"}
         com.taoensso/carmine {:mvn/version "3.1.0"}

--- a/src/toyokumo/commons/ring/response.clj
+++ b/src/toyokumo/commons/ring/response.clj
@@ -1,5 +1,6 @@
 (ns toyokumo.commons.ring.response
   (:require
+   [clojure.string :as str]
    [ring.util.http-response :as res]
    [toyokumo.commons.url :as tc.url]))
 
@@ -43,6 +44,11 @@
 (defn content-disposition [resp value]
   (header resp "Content-Disposition" value))
 
+(defn- encode-filename [filename]
+  (-> filename
+      (tc.url/url-encode)
+      (str/replace "+" " ")))
+
 (defn attachment
   "Use when you want to make a client save response as a file.
   For example:
@@ -51,7 +57,7 @@
          (attachment \"foobar.csv\")
          (csv)))"
   [resp filename]
-  (content-disposition resp (str "attachment; filename=\"" (tc.url/url-encode filename) "\"")))
+  (content-disposition resp (str "attachment; filename=\"" (encode-filename filename) "\"")))
 
 ;;; Specific Content-Type
 

--- a/test/toyokumo/commons/ring/response_test.clj
+++ b/test/toyokumo/commons/ring/response_test.clj
@@ -46,7 +46,19 @@
           :headers {"Content-Disposition" "attachment; filename=\"%E3%81%82%E3%81%84%E3%81%86%E3%81%88%E3%81%8A.csv\""}
           :status 200}
          (-> (ok "test")
-             (attachment "あいうえお.csv")))))
+             (attachment "あいうえお.csv"))))
+
+  (is (= {:body "test"
+          :headers {"Content-Disposition" "attachment; filename=\"hello world.csv\""}
+          :status 200}
+         (-> (ok "test")
+             (attachment "hello world.csv"))))
+
+  (is (= {:body "test"
+          :headers {"Content-Disposition" "attachment; filename=\"hello%2Bworld.csv\""}
+          :status 200}
+         (-> (ok "test")
+             (attachment "hello+world.csv")))))
 
 (deftest csv-test
   (is (= {:body "foo,bar"


### PR DESCRIPTION
Currently `toyokumo.commons.ring.response/attachment` is encoding filename with `url-encode` only.
`url-encode` will replace spaces with `+`, so a file named `hello world.txt` will be downloaded as `hello+world.txt`.

This PR fix this problem.
I've confirmed the browser behavior by Chrome, Firefox, Edge and IE11.