### PR TITLE
Fix attachment to add 'filename*' for Safari

### DIFF
--- a/src/toyokumo/commons/ring/response.clj
+++ b/src/toyokumo/commons/ring/response.clj
@@ -55,9 +55,13 @@
    (let [csv-str \"foo, bar\"]
      (-> (ok csv-str)
          (attachment \"foobar.csv\")
-         (csv)))"
+         (csv)))
+
+  NOTE: Safari does not recognize correct filename when Content-Disposition does not contain filename*.
+        For other browsers, filename* is not required."
   [resp filename]
-  (content-disposition resp (str "attachment; filename=\"" (encode-filename filename) "\"")))
+  (let [encoded-filename (encode-filename filename)]
+    (content-disposition resp (str "attachment; filename=\"" encoded-filename "\"; filename*=UTF-8''" encoded-filename))))
 
 ;;; Specific Content-Type
 

--- a/test/toyokumo/commons/ring/response_test.clj
+++ b/test/toyokumo/commons/ring/response_test.clj
@@ -38,24 +38,24 @@
 (deftest attachment-test
   (is (= {:body "test"
           :status 200
-          :headers {"Content-Disposition" "attachment; filename=\"test.csv\""}}
+          :headers {"Content-Disposition" "attachment; filename=\"test.csv\"; filename*=UTF-8''test.csv"}}
          (-> (ok "test")
              (attachment "test.csv"))))
 
   (is (= {:body "test"
-          :headers {"Content-Disposition" "attachment; filename=\"%E3%81%82%E3%81%84%E3%81%86%E3%81%88%E3%81%8A.csv\""}
+          :headers {"Content-Disposition" "attachment; filename=\"%E3%81%82%E3%81%84%E3%81%86%E3%81%88%E3%81%8A.csv\"; filename*=UTF-8''%E3%81%82%E3%81%84%E3%81%86%E3%81%88%E3%81%8A.csv"}
           :status 200}
          (-> (ok "test")
              (attachment "あいうえお.csv"))))
 
   (is (= {:body "test"
-          :headers {"Content-Disposition" "attachment; filename=\"hello world.csv\""}
+          :headers {"Content-Disposition" "attachment; filename=\"hello world.csv\"; filename*=UTF-8''hello world.csv"}
           :status 200}
          (-> (ok "test")
              (attachment "hello world.csv"))))
 
   (is (= {:body "test"
-          :headers {"Content-Disposition" "attachment; filename=\"hello%2Bworld.csv\""}
+          :headers {"Content-Disposition" "attachment; filename=\"hello%2Bworld.csv\"; filename*=UTF-8''hello%2Bworld.csv"}
           :status 200}
          (-> (ok "test")
              (attachment "hello+world.csv")))))


### PR DESCRIPTION
`toyokumo.commons.ring.response/attachment` does not work correctly for Safari.
Safari does not recognize `filename` in `Content-Disposition` header accurately, ant it need to add `filename*`.

I've tested with Chrome, Firefox, Safari and MS Edge.