### PR TITLE
Enable customizing FirebaseOptions

### DIFF
--- a/src/toyokumo/commons/experimental/firebase/admin_sdk.clj
+++ b/src/toyokumo/commons/experimental/firebase/admin_sdk.clj
@@ -7,9 +7,10 @@
     GoogleCredentials)
    (com.google.firebase
     FirebaseApp
-    FirebaseOptions)))
+    FirebaseOptions
+    FirebaseOptions$Builder)))
 
-(defrecord FirebaseAdmin [service-account-key-path ^FirebaseApp app]
+(defrecord FirebaseAdmin [service-account-key-path ^FirebaseApp app ^FirebaseOptions$Builder options-builder]
   component/Lifecycle
   (start [this]
     (let [f (io/file service-account-key-path)]
@@ -17,7 +18,7 @@
         (throw (IllegalArgumentException. "Firebase service account key file does not exist")))
       (with-open [is (io/input-stream f)]
         (assoc this
-               :app (let [opts (-> (FirebaseOptions/builder)
+               :app (let [opts (-> (or options-builder (FirebaseOptions/builder))
                                    (.setCredentials (GoogleCredentials/fromStream is))
                                    (.build))]
                       (FirebaseApp/initializeApp opts))))))

--- a/src/toyokumo/commons/experimental/firebase/admin_sdk.clj
+++ b/src/toyokumo/commons/experimental/firebase/admin_sdk.clj
@@ -1,4 +1,11 @@
 (ns toyokumo.commons.experimental.firebase.admin-sdk
+  "Provides a component which initializes FirebasApp with the
+  `com.stuartsierra.component/Component` lifecycle.
+
+  service-account-key-path  - required. File path to the firebase service account key.
+  options-builder           - optional. An instance of FirebaseOptions$Builder. Use to customize FirebaseApp initialization.
+
+  See for more detail on Component at https://github.com/stuartsierra/component."
   (:require
    [clojure.java.io :as io]
    [com.stuartsierra.component :as component])


### PR DESCRIPTION
Currently, it seems to be that we can not setup FirebaseOption freely because  the code of building FirebaseOptions  is hard coded.

https://github.com/toyokumo/toyokumo-commons/blob/5b6c858eb6c8f996a3c991e047784b75a41865f1/src/toyokumo/commons/experimental/firebase/admin_sdk.clj#L12-L23

It might be problem when we want to use firebase storage (for example) from firebase-admin-sdk.

So I added additional option named `options-builder` to enable custom setup of FirebaseApp initialization.

In the case when you want to use firebase storage from admin-sdk, for example, you can use this option like below.
```clojure
(tc.firebase/map->FirebaseAdmin (assoc (:firebase config)
                                                :options-builder
                                                (-> (FirebaseOptions/builder)
                                                    (.setStorageBucket (get-in config [:firebase :storageBucket])))))

;; assuming that
;; - toyokumo.commons.experimental.firebase.admin-sdk is required as tc.firebase
;; - `config` is a map containing a value, which represents FirebaseAdmin record values, with key `:firebase`

```