### PR TITLE
Bump deps

### DIFF
--- a/.clj-kondo/com.github.seancorfield/next.jdbc/config.edn
+++ b/.clj-kondo/com.github.seancorfield/next.jdbc/config.edn
@@ -1,0 +1,4 @@
+{:hooks
+ {:analyze-call
+  {next.jdbc/with-transaction
+   hooks.com.github.seancorfield.next-jdbc/with-transaction}}}

--- a/.clj-kondo/com.github.seancorfield/next.jdbc/hooks/com/github/seancorfield/next_jdbc.clj
+++ b/.clj-kondo/com.github.seancorfield/next.jdbc/hooks/com/github/seancorfield/next_jdbc.clj
@@ -1,0 +1,19 @@
+(ns hooks.com.github.seancorfield.next-jdbc
+  (:require
+   [clj-kondo.hooks-api :as api]))
+
+(defn with-transaction
+  "Expands (with-transaction [tx expr opts] body)
+  to (let [tx expr] opts body) pre clj-kondo examples."
+  [{:keys [:node]}]
+  (let [[binding-vec & body] (rest (:children node))
+        [sym val opts] (:children binding-vec)]
+    (when-not (and sym val)
+      (throw (ex-info "No sym and val provided" {})))
+    (let [new-node (api/list-node
+                    (list*
+                     (api/token-node 'let)
+                     (api/vector-node [sym val])
+                     opts
+                     body))]
+      {:node new-node})))

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -38,14 +38,8 @@ jobs:
       - uses: DeLaGuardo/setup-clojure@master
         with:
           cli: latest
-
-      - uses: 0918nobita/setup-cljstyle@v0.5.4
-        with:
-          cljstyle-version: '0.16.626'
-
-      - uses: DeLaGuardo/setup-clj-kondo@master
-        with:
-          version: '2024.05.24'
+          cljstyle: latest
+          clj-kondo: latest
 
       - name: Show versions
         run: |

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -26,9 +26,9 @@ jobs:
           - 6379:6379
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
           java-version: '11'
@@ -39,13 +39,13 @@ jobs:
         with:
           cli: latest
 
-      - uses: 0918nobita/setup-cljstyle@v0.2.0
+      - uses: 0918nobita/setup-cljstyle@v0.5.4
         with:
-          cljstyle-version: '0.15.0'
+          cljstyle-version: '0.16.626'
 
       - uses: DeLaGuardo/setup-clj-kondo@master
         with:
-          version: '2022.04.25'
+          version: '2024.05.24'
 
       - name: Show versions
         run: |
@@ -55,7 +55,7 @@ jobs:
           clj-kondo --version
 
       - name: Cache dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.m2
           key: clj-cache-${{ hashFiles('**/deps.edn') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,11 +7,11 @@ jobs:
     runs-on: ubuntu-latest
     permissions: write-all
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
           java-version: '11'
@@ -28,7 +28,7 @@ jobs:
           clojure --version
 
       - name: Cache dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.m2
           key: clj-cache-${{ hashFiles('**/deps.edn') }}

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ pom.xml.asc
 .idea/replstate.xml
 .idea/httpRequests
 .idea/libraries/
+
+.lsp/

--- a/.gitignore
+++ b/.gitignore
@@ -33,5 +33,7 @@ pom.xml.asc
 .idea/replstate.xml
 .idea/httpRequests
 .idea/libraries/
+.idea/git_toolbox_blame.xml
+.idea/git_toolbox_prj.xml
 
 .lsp/

--- a/deps.edn
+++ b/deps.edn
@@ -1,37 +1,37 @@
 {:paths ["src" "src-cljs" "src-cljc"]
- :deps {org.clojure/clojure {:mvn/version "1.11.1"}
-        org.clojure/core.async {:mvn/version "1.5.648"}
-        prismatic/schema {:mvn/version "1.2.0"}
-        camel-snake-kebab/camel-snake-kebab {:mvn/version "0.4.2"}
-        com.cognitect/transit-clj {:mvn/version "1.0.329"}
-        com.cognitect/transit-cljs {:mvn/version "0.8.269"}
-        commons-codec/commons-codec {:mvn/version "1.15"}
-        metosin/ring-http-response {:mvn/version "0.9.3" :exclusions [ring/ring-core]}
-        org.apache.commons/commons-csv {:mvn/version "1.9.0"}
-        commons-io/commons-io {:mvn/version "2.11.0"}
-        info.sunng/ring-jetty9-adapter {:mvn/version "0.17.6"}
+ :deps {org.clojure/clojure {:mvn/version "1.11.3"}
+        org.clojure/core.async {:mvn/version "1.6.681"}
+        prismatic/schema {:mvn/version "1.4.1"}
+        camel-snake-kebab/camel-snake-kebab {:mvn/version "0.4.3"}
+        com.cognitect/transit-clj {:mvn/version "1.0.333"}
+        com.cognitect/transit-cljs {:mvn/version "0.8.280"}
+        commons-codec/commons-codec {:mvn/version "1.17.1"}
+        metosin/ring-http-response {:mvn/version "0.9.4"}
+        org.apache.commons/commons-csv {:mvn/version "1.11.0"}
+        commons-io/commons-io {:mvn/version "2.16.1"}
+        info.sunng/ring-jetty9-adapter {:mvn/version "0.22.6"}
         com.stuartsierra/component {:mvn/version "1.1.0"}
-        hikari-cp/hikari-cp {:mvn/version "2.14.0" :exclusions [org.slf4j/slf4j-api]}
-        com.github.seancorfield/next.jdbc {:mvn/version "1.2.772"}
-        metosin/jsonista {:mvn/version "0.3.5"}
-        com.taoensso/carmine {:mvn/version "3.1.0"}
-        org.clojure/tools.logging {:mvn/version "1.2.4"}
-        org.eclipse.angus/angus-mail {:mvn/version "2.0.2"}
-        clj-http/clj-http {:mvn/version "3.12.3"}
-        diehard/diehard {:mvn/version "0.11.3"}}
+        hikari-cp/hikari-cp {:mvn/version "3.1.0" :exclusions [org.slf4j/slf4j-api]}
+        com.github.seancorfield/next.jdbc {:mvn/version "1.3.939"}
+        metosin/jsonista {:mvn/version "0.3.9"}
+        com.taoensso/carmine {:mvn/version "3.4.1"}
+        org.clojure/tools.logging {:mvn/version "1.3.0"}
+        org.eclipse.angus/angus-mail {:mvn/version "2.0.3"}
+        clj-http/clj-http {:mvn/version "3.13.0"}
+        diehard/diehard {:mvn/version "0.11.12"}}
  :aliases
  {:dev {:extra-paths ["test" "dev-resources"]
-        :extra-deps {org.postgresql/postgresql {:mvn/version "42.3.3"}
-                     lambdaisland/kaocha {:mvn/version "1.66.1034"}
+        :extra-deps {org.postgresql/postgresql {:mvn/version "42.7.3"}
+                     lambdaisland/kaocha {:mvn/version "1.91.1392"}
                      ;; experimental
-                     com.walmartlabs/lacinia {:mvn/version "1.2"}
-                     superlifter/superlifter {:mvn/version "0.1.3"}
-                     com.google.firebase/firebase-admin {:mvn/version "8.1.0"}}}
+                     com.walmartlabs/lacinia {:mvn/version "1.2.2"}
+                     superlifter/superlifter {:mvn/version "0.1.5"}
+                     com.google.firebase/firebase-admin {:mvn/version "9.3.0"}}}
 
   :test {:main-opts ["-m" "kaocha.runner"]}
 
   :build
-  {:deps {com.github.liquidz/build.edn {:git/tag "0.7.145" :git/sha "776501e"}}
+  {:deps {com.github.liquidz/build.edn {:git/tag "0.11.266" :git/sha "849302d"}}
    :ns-default build-edn.main}
 
   :outdated

--- a/toyokumo-commons.iml
+++ b/toyokumo-commons.iml
@@ -17,203 +17,207 @@
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="library" name="Deps: com.cognitect/transit-java:1.0.362" level="project" />
-    <orderEntry type="library" name="Deps: com.google.cloud/google-cloud-firestore:2.6.1" level="project" />
+    <orderEntry type="library" name="Deps: com.cognitect/transit-java:1.0.371" level="project" />
+    <orderEntry type="library" name="Deps: com.google.cloud/google-cloud-firestore:3.21.1" level="project" />
     <orderEntry type="library" name="Deps: org.clojure/data.json:2.4.0" level="project" />
-    <orderEntry type="library" name="Deps: org.lz4/lz4-java:1.7.1" level="project" />
-    <orderEntry type="library" name="Deps: org.clojure/clojure:1.11.1" level="project" />
+    <orderEntry type="library" name="Deps: org.clojure/clojure:1.11.3" level="project" />
+    <orderEntry type="library" name="Deps: lambdaisland/deep-diff2:2.11.216" level="project" />
+    <orderEntry type="library" name="Deps: org.eclipse.angus/angus-mail:2.0.3" level="project" />
+    <orderEntry type="library" name="Deps: javax.activation/javax.activation-api:1.2.0" level="project" />
     <orderEntry type="library" name="Deps: com.ibm.icu/icu4j:69.1" level="project" />
-    <orderEntry type="library" name="Deps: commons-codec:1.15" level="project" />
-    <orderEntry type="library" name="Deps: org.clojure/tools.analyzer:1.1.0" level="project" />
-    <orderEntry type="library" name="Deps: org.eclipse.jetty/jetty-xml:10.0.9" level="project" />
-    <orderEntry type="library" name="Deps: com.zaxxer/HikariCP:4.0.3" level="project" />
-    <orderEntry type="library" name="Deps: org.eclipse.jetty/jetty-servlet:10.0.9" level="project" />
-    <orderEntry type="library" name="Deps: com.google.errorprone/error_prone_annotations:2.7.1" level="project" />
-    <orderEntry type="library" name="Deps: org.clojure/tools.logging:1.2.4" level="project" />
-    <orderEntry type="library" name="Deps: metosin/ring-http-response:0.9.3" level="project" />
+    <orderEntry type="library" name="Deps: commons-codec:1.17.1" level="project" />
+    <orderEntry type="library" name="Deps: org.clojure/tools.analyzer:1.1.1" level="project" />
+    <orderEntry type="library" name="Deps: org.eclipse.jetty/jetty-xml:11.0.20" level="project" />
+    <orderEntry type="library" name="Deps: com.zaxxer/HikariCP:5.1.0" level="project" />
+    <orderEntry type="library" name="Deps: org.eclipse.jetty/jetty-servlet:11.0.20" level="project" />
+    <orderEntry type="library" name="Deps: com.google.errorprone/error_prone_annotations:2.26.1" level="project" />
+    <orderEntry type="library" name="Deps: org.clojure/tools.logging:1.3.0" level="project" />
+    <orderEntry type="library" name="Deps: metosin/ring-http-response:0.9.4" level="project" />
     <orderEntry type="library" name="Deps: org.clojure/core.specs.alpha:0.2.62" level="project" />
-    <orderEntry type="library" name="Deps: org.eclipse.jetty.websocket/websocket-jetty-api:10.0.9" level="project" />
-    <orderEntry type="library" name="Deps: org.tukaani/xz:1.8" level="project" />
-    <orderEntry type="library" name="Deps: org.eclipse.jetty.websocket/websocket-jetty-common:10.0.9" level="project" />
-    <orderEntry type="library" name="Deps: com.google.cloud/google-cloud-core-http:1.95.4" level="project" />
+    <orderEntry type="library" name="Deps: org.eclipse.jetty.websocket/websocket-jetty-api:11.0.20" level="project" />
+    <orderEntry type="library" name="Deps: org.tukaani/xz:1.9" level="project" />
+    <orderEntry type="library" name="Deps: org.eclipse.jetty.websocket/websocket-jetty-common:11.0.20" level="project" />
+    <orderEntry type="library" name="Deps: com.google.cloud/google-cloud-core-http:2.38.0" level="project" />
     <orderEntry type="library" name="Deps: javax.annotation/javax.annotation-api:1.3.2" level="project" />
-    <orderEntry type="library" name="Deps: com.google.oauth-client/google-oauth-client:1.31.5" level="project" />
-    <orderEntry type="library" name="Deps: com.google.auto.value/auto-value-annotations:1.8.1" level="project" />
-    <orderEntry type="library" name="Deps: io.netty/netty-common:4.1.67.Final" level="project" />
-    <orderEntry type="library" name="Deps: lambdaisland/kaocha:1.66.1034" level="project" />
-    <orderEntry type="library" name="Deps: com.google.auth/google-auth-library-credentials:0.26.0" level="project" />
-    <orderEntry type="library" name="Deps: com.fasterxml.jackson.core/jackson-databind:2.13.0" level="project" />
+    <orderEntry type="library" name="Deps: com.google.oauth-client/google-oauth-client:1.35.0" level="project" />
+    <orderEntry type="library" name="Deps: com.google.auto.value/auto-value-annotations:1.10.4" level="project" />
+    <orderEntry type="library" name="Deps: io.netty/netty-common:4.1.109.Final" level="project" />
+    <orderEntry type="library" name="Deps: lambdaisland/kaocha:1.91.1392" level="project" />
+    <orderEntry type="library" name="Deps: com.google.auth/google-auth-library-credentials:1.23.0" level="project" />
+    <orderEntry type="library" name="Deps: com.fasterxml.jackson.core/jackson-databind:2.17.1" level="project" />
     <orderEntry type="library" name="Deps: expound:0.9.0" level="project" />
-    <orderEntry type="library" name="Deps: org.clojure/spec.alpha:0.3.218" level="project" />
+    <orderEntry type="library" name="Deps: org.clojure/spec.alpha:0.4.233" level="project" />
     <orderEntry type="library" name="Deps: org.antlr/antlr4-runtime:4.9.3" level="project" />
-    <orderEntry type="library" name="Deps: org.clojure/tools.cli:1.0.206" level="project" />
-    <orderEntry type="library" name="Deps: org.eclipse.jetty.http2/http2-server:10.0.9" level="project" />
-    <orderEntry type="library" name="Deps: com.google.api.grpc/proto-google-iam-v1:1.0.14" level="project" />
-    <orderEntry type="library" name="Deps: mvxcvi/puget:1.1.2" level="project" />
-    <orderEntry type="library" name="Deps: commons-fileupload:1.4" level="project" />
-    <orderEntry type="library" name="Deps: org.codehaus.mojo/animal-sniffer-annotations:1.20" level="project" />
-    <orderEntry type="library" name="Deps: io.perfmark/perfmark-api:0.23.0" level="project" />
-    <orderEntry type="library" name="Deps: jakarta.transaction/jakarta.transaction-api:1.3.3" level="project" />
-    <orderEntry type="library" name="Deps: org.eclipse.jetty/jetty-http:10.0.9" level="project" />
-    <orderEntry type="library" name="Deps: org.eclipse.jetty/jetty-util:10.0.9" level="project" />
-    <orderEntry type="library" name="Deps: com.taoensso/encore:3.9.2" level="project" />
-    <orderEntry type="library" name="Deps: com.google.firebase/firebase-admin:8.1.0" level="project" />
-    <orderEntry type="library" name="Deps: org.apache.commons/commons-pool2:2.9.0" level="project" />
-    <orderEntry type="library" name="Deps: org.apache.httpcomponents/httpasyncclient:4.1.4" level="project" />
-    <orderEntry type="library" name="Deps: org.clojure/tools.analyzer.jvm:1.2.2" level="project" />
+    <orderEntry type="library" name="Deps: org.clojure/tools.cli:1.1.230" level="project" />
+    <orderEntry type="library" name="Deps: org.eclipse.jetty.http2/http2-server:11.0.20" level="project" />
+    <orderEntry type="library" name="Deps: org.eclipse.jetty.toolchain/jetty-jakarta-servlet-api:5.0.2" level="project" />
+    <orderEntry type="library" name="Deps: com.google.api.grpc/proto-google-iam-v1:1.34.0" level="project" />
+    <orderEntry type="library" name="Deps: org.codehaus.mojo/animal-sniffer-annotations:1.23" level="project" />
+    <orderEntry type="library" name="Deps: lambdaisland/clj-diff:1.4.78" level="project" />
+    <orderEntry type="library" name="Deps: io.perfmark/perfmark-api:0.27.0" level="project" />
+    <orderEntry type="library" name="Deps: org.eclipse.jetty/jetty-http:11.0.20" level="project" />
+    <orderEntry type="library" name="Deps: org.eclipse.jetty/jetty-util:11.0.20" level="project" />
+    <orderEntry type="library" name="Deps: com.taoensso/encore:3.112.0" level="project" />
+    <orderEntry type="library" name="Deps: com.google.firebase/firebase-admin:9.3.0" level="project" />
+    <orderEntry type="library" name="Deps: org.apache.commons/commons-pool2:2.12.0" level="project" />
+    <orderEntry type="library" name="Deps: org.apache.httpcomponents/httpasyncclient:4.1.5" level="project" />
+    <orderEntry type="library" name="Deps: org.clojure/tools.analyzer.jvm:1.2.3" level="project" />
     <orderEntry type="library" name="Deps: net.incongru.watchservice/barbary-watchservice:1.0" level="project" />
-    <orderEntry type="library" name="Deps: com.google.protobuf/protobuf-java-util:3.17.3" level="project" />
-    <orderEntry type="library" name="Deps: com.google.cloud/google-cloud-storage:1.118.0" level="project" />
+    <orderEntry type="library" name="Deps: com.google.protobuf/protobuf-java-util:3.25.3" level="project" />
+    <orderEntry type="library" name="Deps: com.google.cloud/google-cloud-storage:2.38.0" level="project" />
+    <orderEntry type="library" name="Deps: io.grpc/grpc-services:1.62.2" level="project" />
     <orderEntry type="library" name="Deps: com.google.android/annotations:4.1.1.4" level="project" />
     <orderEntry type="library" name="Deps: funcool/urania:0.2.0" level="project" />
-    <orderEntry type="library" name="Deps: diehard:0.11.3" level="project" />
-    <orderEntry type="library" name="Deps: io.netty/netty-codec:4.1.67.Final" level="project" />
+    <orderEntry type="library" name="Deps: diehard:0.11.12" level="project" />
+    <orderEntry type="library" name="Deps: io.netty/netty-codec:4.1.109.Final" level="project" />
     <orderEntry type="library" name="Deps: org.antlr/ST4:4.3.1" level="project" />
-    <orderEntry type="library" name="Deps: com.google.api/api-common:1.10.4" level="project" />
-    <orderEntry type="library" name="Deps: org.eclipse.jetty/jetty-annotations:10.0.9" level="project" />
-    <orderEntry type="library" name="Deps: lambdaisland/deep-diff:0.0-47" level="project" />
-    <orderEntry type="library" name="Deps: io.grpc/grpc-protobuf-lite:1.39.0" level="project" />
-    <orderEntry type="library" name="Deps: org.eclipse.jetty.websocket/websocket-core-common:10.0.9" level="project" />
+    <orderEntry type="library" name="Deps: com.google.api/api-common:2.31.0" level="project" />
+    <orderEntry type="library" name="Deps: io.grpc/grpc-protobuf-lite:1.62.2" level="project" />
+    <orderEntry type="library" name="Deps: org.eclipse.jetty.websocket/websocket-core-common:11.0.20" level="project" />
     <orderEntry type="library" name="Deps: com.googlecode.json-simple/json-simple:1.1.1" level="project" />
-    <orderEntry type="library" name="Deps: io.grpc/grpc-alts:1.39.0" level="project" />
-    <orderEntry type="library" name="Deps: dev.failsafe/failsafe:3.2.3" level="project" />
-    <orderEntry type="library" name="Deps: org.iq80.snappy/snappy:0.4" level="project" />
-    <orderEntry type="library" name="Deps: com.google.cloud/google-cloud-core-grpc:1.95.4" level="project" />
-    <orderEntry type="library" name="Deps: com.cognitect/transit-cljs:0.8.269" level="project" />
-    <orderEntry type="library" name="Deps: io.aviso/pretty:0.1.37" level="project" />
+    <orderEntry type="library" name="Deps: io.grpc/grpc-alts:1.62.2" level="project" />
+    <orderEntry type="library" name="Deps: dev.failsafe/failsafe:3.3.2" level="project" />
+    <orderEntry type="library" name="Deps: com.google.cloud/google-cloud-core-grpc:2.38.0" level="project" />
+    <orderEntry type="library" name="Deps: com.cognitect/transit-cljs:0.8.280" level="project" />
     <orderEntry type="library" name="Deps: org.abego.treelayout/org.abego.treelayout.core:1.0.3" level="project" />
-    <orderEntry type="library" name="Deps: io.netty/netty-buffer:4.1.67.Final" level="project" />
+    <orderEntry type="library" name="Deps: io.netty/netty-buffer:4.1.109.Final" level="project" />
+    <orderEntry type="library" name="Deps: io.opencensus/opencensus-proto:0.2.0" level="project" />
     <orderEntry type="library" name="Deps: slingshot:0.12.2" level="project" />
-    <orderEntry type="library" name="Deps: org.apache.httpcomponents/httpcore-nio:4.4.10" level="project" />
+    <orderEntry type="library" name="Deps: org.apache.httpcomponents/httpcore-nio:4.4.15" level="project" />
+    <orderEntry type="library" name="Deps: com.google.api.grpc/proto-google-cloud-storage-v2:2.38.0-alpha" level="project" />
     <orderEntry type="library" name="Deps: com.stuartsierra/component:1.1.0" level="project" />
-    <orderEntry type="library" name="Deps: io.netty/netty-handler:4.1.67.Final" level="project" />
+    <orderEntry type="library" name="Deps: io.netty/netty-handler:4.1.109.Final" level="project" />
     <orderEntry type="library" name="Deps: org.flatland/ordered:1.15.10" level="project" />
-    <orderEntry type="library" name="Deps: io.grpc/grpc-context:1.39.0" level="project" />
-    <orderEntry type="library" name="Deps: com.taoensso/carmine:3.1.0" level="project" />
-    <orderEntry type="library" name="Deps: commons-io:2.11.0" level="project" />
+    <orderEntry type="library" name="Deps: io.grpc/grpc-context:1.62.2" level="project" />
+    <orderEntry type="library" name="Deps: com.taoensso/carmine:3.4.1" level="project" />
+    <orderEntry type="library" name="Deps: commons-io:2.16.1" level="project" />
     <orderEntry type="library" name="Deps: com.google.guava/listenablefuture:9999.0-empty-to-avoid-conflict-with-guava" level="project" />
-    <orderEntry type="library" name="Deps: com.google.http-client/google-http-client-jackson2:1.39.2" level="project" />
-    <orderEntry type="library" name="Deps: org.eclipse.jetty.websocket/websocket-core-server:10.0.9" level="project" />
-    <orderEntry type="library" name="Deps: org.postgresql/postgresql:42.3.3" level="project" />
-    <orderEntry type="library" name="Deps: org.eclipse.jetty.http2/http2-hpack:10.0.9" level="project" />
-    <orderEntry type="library" name="Deps: fipp:0.6.17" level="project" />
-    <orderEntry type="library" name="Deps: org.eclipse.jetty/jetty-plus:10.0.9" level="project" />
-    <orderEntry type="library" name="Deps: com.walmartlabs/lacinia:1.2" level="project" />
-    <orderEntry type="library" name="Deps: com.nextjournal/beholder:1.0.0" level="project" />
-    <orderEntry type="library" name="Deps: com.fasterxml.jackson.core/jackson-core:2.13.0" level="project" />
-    <orderEntry type="library" name="Deps: org.eclipse.jetty.websocket/websocket-servlet:10.0.9" level="project" />
+    <orderEntry type="library" name="Deps: com.google.http-client/google-http-client-jackson2:1.44.1" level="project" />
+    <orderEntry type="library" name="Deps: org.eclipse.jetty.websocket/websocket-core-server:11.0.20" level="project" />
+    <orderEntry type="library" name="Deps: org.postgresql/postgresql:42.7.3" level="project" />
+    <orderEntry type="library" name="Deps: org.eclipse.jetty.http2/http2-hpack:11.0.20" level="project" />
+    <orderEntry type="library" name="Deps: fipp:0.6.26" level="project" />
+    <orderEntry type="library" name="Deps: com.walmartlabs/lacinia:1.2.2" level="project" />
+    <orderEntry type="library" name="Deps: com.nextjournal/beholder:1.0.2" level="project" />
+    <orderEntry type="library" name="Deps: com.fasterxml.jackson.core/jackson-core:2.17.1" level="project" />
+    <orderEntry type="library" name="Deps: org.apache.commons/commons-fileupload2-core:2.0.0-M1" level="project" />
+    <orderEntry type="library" name="Deps: org.eclipse.jetty.websocket/websocket-servlet:11.0.20" level="project" />
     <orderEntry type="library" name="Deps: aero:1.1.6" level="project" />
     <orderEntry type="library" name="Deps: org.tobereplaced/lettercase:1.0.0" level="project" />
-    <orderEntry type="library" name="Deps: clj-http:3.12.3" level="project" />
+    <orderEntry type="library" name="Deps: clj-http:3.13.0" level="project" />
     <orderEntry type="library" name="Deps: org.ow2.asm/asm:9.2" level="project" />
-    <orderEntry type="library" name="Deps: org.eclipse.jetty.websocket/websocket-jetty-server:10.0.9" level="project" />
-    <orderEntry type="library" name="Deps: lambdaisland/tools.namespace:0.1.247" level="project" />
-    <orderEntry type="library" name="Deps: io.grpc/grpc-stub:1.39.0" level="project" />
-    <orderEntry type="library" name="Deps: org.apache.httpcomponents/httpcore:4.4.14" level="project" />
-    <orderEntry type="library" name="Deps: org.eclipse.jetty/jetty-security:10.0.9" level="project" />
-    <orderEntry type="library" name="Deps: org.apache.httpcomponents/httpclient-cache:4.5.13" level="project" />
-    <orderEntry type="library" name="Deps: mvxcvi/arrangement:1.2.0" level="project" />
-    <orderEntry type="library" name="Deps: jakarta.annotation/jakarta.annotation-api:1.3.5" level="project" />
-    <orderEntry type="library" name="Deps: com.google.api-client/google-api-client-gson:1.32.1" level="project" />
-    <orderEntry type="library" name="Deps: com.google.http-client/google-http-client:1.39.2" level="project" />
-    <orderEntry type="library" name="Deps: com.google.http-client/google-http-client-appengine:1.39.2" level="project" />
+    <orderEntry type="library" name="Deps: com.google.api.grpc/grpc-google-cloud-storage-v2:2.38.0-alpha" level="project" />
+    <orderEntry type="library" name="Deps: org.eclipse.jetty.websocket/websocket-jetty-server:11.0.20" level="project" />
+    <orderEntry type="library" name="Deps: io.grpc/grpc-inprocess:1.62.2" level="project" />
+    <orderEntry type="library" name="Deps: lambdaisland/tools.namespace:0.3.256" level="project" />
+    <orderEntry type="library" name="Deps: io.grpc/grpc-stub:1.62.2" level="project" />
+    <orderEntry type="library" name="Deps: io.grpc/grpc-googleapis:1.62.2" level="project" />
+    <orderEntry type="library" name="Deps: org.apache.httpcomponents/httpcore:4.4.16" level="project" />
+    <orderEntry type="library" name="Deps: org.eclipse.jetty/jetty-security:11.0.20" level="project" />
+    <orderEntry type="library" name="Deps: org.apache.httpcomponents/httpclient-cache:4.5.14" level="project" />
+    <orderEntry type="library" name="Deps: mvxcvi/arrangement:2.1.0" level="project" />
+    <orderEntry type="library" name="Deps: com.google.api.grpc/gapic-google-cloud-storage-v2:2.38.0-alpha" level="project" />
+    <orderEntry type="library" name="Deps: com.google.api-client/google-api-client-gson:2.4.0" level="project" />
+    <orderEntry type="library" name="Deps: io.grpc/grpc-util:1.62.2" level="project" />
+    <orderEntry type="library" name="Deps: com.google.http-client/google-http-client:1.44.1" level="project" />
+    <orderEntry type="library" name="Deps: com.google.http-client/google-http-client-appengine:1.44.1" level="project" />
     <orderEntry type="library" name="Deps: com.cognitect/transit-js:0.8.874" level="project" />
-    <orderEntry type="library" name="Deps: io.methvin/directory-watcher:0.15.0" level="project" />
-    <orderEntry type="library" name="Deps: clj-tuple:0.2.2" level="project" />
-    <orderEntry type="library" name="Deps: com.taoensso/truss:1.6.0" level="project" />
+    <orderEntry type="library" name="Deps: io.methvin/directory-watcher:0.17.3" level="project" />
+    <orderEntry type="library" name="Deps: io.airlift/aircompressor:0.27" level="project" />
+    <orderEntry type="library" name="Deps: com.taoensso/truss:1.11.0" level="project" />
     <orderEntry type="library" name="Deps: org.antlr/antlr-runtime:3.5.2" level="project" />
-    <orderEntry type="library" name="Deps: com.fasterxml.jackson.core/jackson-annotations:2.13.0" level="project" />
-    <orderEntry type="library" name="Deps: com.google.apis/google-api-services-storage:v1-rev20210127-1.32.1" level="project" />
+    <orderEntry type="library" name="Deps: com.fasterxml.jackson.core/jackson-annotations:2.17.1" level="project" />
+    <orderEntry type="library" name="Deps: com.google.apis/google-api-services-storage:v1-rev20240319-2.0.0" level="project" />
     <orderEntry type="library" name="Deps: riddley:0.1.12" level="project" />
     <orderEntry type="library" name="Deps: progrock:0.1.2" level="project" />
+    <orderEntry type="library" name="Deps: jakarta.mail/jakarta.mail-api:2.1.3" level="project" />
     <orderEntry type="library" name="Deps: org.javassist/javassist:3.18.1-GA" level="project" />
-    <orderEntry type="library" name="Deps: org.eclipse.jetty/jetty-webapp:10.0.9" level="project" />
-    <orderEntry type="library" name="Deps: org.checkerframework/checker-compat-qual:2.5.5" level="project" />
+    <orderEntry type="library" name="Deps: org.eclipse.jetty/jetty-webapp:11.0.20" level="project" />
     <orderEntry type="library" name="Deps: org.clojure/java.classpath:1.0.0" level="project" />
-    <orderEntry type="library" name="Deps: org.eclipse.jetty/jetty-alpn-java-server:10.0.9" level="project" />
+    <orderEntry type="library" name="Deps: org.eclipse.jetty/jetty-alpn-java-server:11.0.20" level="project" />
     <orderEntry type="library" name="Deps: commons-logging:1.2" level="project" />
-    <orderEntry type="library" name="Deps: com.google.guava/failureaccess:1.0.1" level="project" />
-    <orderEntry type="library" name="Deps: superlifter:0.1.3" level="project" />
-    <orderEntry type="library" name="Deps: com.google.guava/guava:30.1.1-android" level="project" />
-    <orderEntry type="library" name="Deps: io.grpc/grpc-protobuf:1.39.0" level="project" />
-    <orderEntry type="library" name="Deps: io.grpc/grpc-api:1.39.0" level="project" />
-    <orderEntry type="library" name="Deps: org.eclipse.jetty.http2/http2-common:10.0.9" level="project" />
-    <orderEntry type="library" name="Deps: org.threeten/threetenbp:1.5.1" level="project" />
+    <orderEntry type="library" name="Deps: com.google.guava/failureaccess:1.0.2" level="project" />
+    <orderEntry type="library" name="Deps: superlifter:0.1.5" level="project" />
+    <orderEntry type="library" name="Deps: com.google.guava/guava:33.1.0-jre" level="project" />
+    <orderEntry type="library" name="Deps: io.grpc/grpc-protobuf:1.62.2" level="project" />
+    <orderEntry type="library" name="Deps: io.grpc/grpc-api:1.62.2" level="project" />
+    <orderEntry type="library" name="Deps: org.eclipse.jetty.http2/http2-common:11.0.20" level="project" />
+    <orderEntry type="library" name="Deps: org.threeten/threetenbp:1.6.9" level="project" />
     <orderEntry type="library" name="Deps: org.msgpack/msgpack:0.6.12" level="project" />
-    <orderEntry type="library" name="Deps: com.google.j2objc/j2objc-annotations:1.3" level="project" />
-    <orderEntry type="library" name="Deps: com.taoensso/timbre:5.1.0" level="project" />
-    <orderEntry type="library" name="Deps: com.google.api.grpc/proto-google-common-protos:2.3.2" level="project" />
-    <orderEntry type="library" name="Deps: com.cognitect/transit-clj:1.0.329" level="project" />
-    <orderEntry type="library" name="Deps: com.google.api/gax-grpc:1.66.0" level="project" />
-    <orderEntry type="library" name="Deps: com.github.seancorfield/next.jdbc:1.2.772" level="project" />
-    <orderEntry type="library" name="Deps: com.google.http-client/google-http-client-gson:1.39.2" level="project" />
-    <orderEntry type="library" name="Deps: io.netty/netty-transport:4.1.67.Final" level="project" />
-    <orderEntry type="library" name="Deps: com.google.api/gax-httpjson:0.83.0" level="project" />
-    <orderEntry type="library" name="Deps: org.ow2.asm/asm-commons:9.2" level="project" />
+    <orderEntry type="library" name="Deps: com.google.j2objc/j2objc-annotations:3.0.0" level="project" />
+    <orderEntry type="library" name="Deps: com.taoensso/timbre:6.5.0" level="project" />
+    <orderEntry type="library" name="Deps: com.google.api.grpc/proto-google-common-protos:2.39.0" level="project" />
+    <orderEntry type="library" name="Deps: com.cognitect/transit-clj:1.0.333" level="project" />
+    <orderEntry type="library" name="Deps: com.google.api/gax-grpc:2.48.0" level="project" />
+    <orderEntry type="library" name="Deps: com.github.seancorfield/next.jdbc:1.3.939" level="project" />
+    <orderEntry type="library" name="Deps: com.google.http-client/google-http-client-gson:1.44.1" level="project" />
+    <orderEntry type="library" name="Deps: io.netty/netty-transport:4.1.109.Final" level="project" />
+    <orderEntry type="library" name="Deps: com.google.api/gax-httpjson:2.48.0" level="project" />
     <orderEntry type="library" name="Deps: crypto-random:1.2.1" level="project" />
-    <orderEntry type="library" name="Deps: io.opencensus/opencensus-contrib-http-util:0.28.0" level="project" />
-    <orderEntry type="library" name="Deps: io.netty/netty-codec-http:4.1.67.Final" level="project" />
-    <orderEntry type="library" name="Deps: ring/ring-codec:1.1.3" level="project" />
-    <orderEntry type="library" name="Deps: org.apache.httpcomponents/httpclient:4.5.13" level="project" />
-    <orderEntry type="library" name="Deps: org.conscrypt/conscrypt-openjdk-uber:2.5.1" level="project" />
-    <orderEntry type="library" name="Deps: org.clojure/core.rrb-vector:0.0.14" level="project" />
-    <orderEntry type="library" name="Deps: prismatic/schema:1.2.0" level="project" />
-    <orderEntry type="library" name="Deps: hikari-cp:2.14.0" level="project" />
-    <orderEntry type="library" name="Deps: com.google.cloud/google-cloud-core:1.95.4" level="project" />
-    <orderEntry type="library" name="Deps: crypto-equality:1.0.0" level="project" />
-    <orderEntry type="library" name="Deps: funcool/promesa:5.1.0" level="project" />
-    <orderEntry type="library" name="Deps: org.checkerframework/checker-qual:3.5.0" level="project" />
-    <orderEntry type="library" name="Deps: io.grpc/grpc-core:1.39.0" level="project" />
-    <orderEntry type="library" name="Deps: net.java.dev.jna/jna:5.7.0" level="project" />
-    <orderEntry type="library" name="Deps: org.eclipse.jetty/jetty-jndi:10.0.9" level="project" />
-    <orderEntry type="library" name="Deps: org.eclipse.jetty/jetty-io:10.0.9" level="project" />
-    <orderEntry type="library" name="Deps: org.clojure/tools.reader:1.3.6" level="project" />
+    <orderEntry type="library" name="Deps: io.netty/netty-transport-native-unix-common:4.1.109.Final" level="project" />
+    <orderEntry type="library" name="Deps: io.opencensus/opencensus-contrib-http-util:0.31.1" level="project" />
+    <orderEntry type="library" name="Deps: io.netty/netty-codec-http:4.1.109.Final" level="project" />
+    <orderEntry type="library" name="Deps: ring/ring-codec:1.2.0" level="project" />
+    <orderEntry type="library" name="Deps: org.apache.httpcomponents/httpclient:4.5.14" level="project" />
+    <orderEntry type="library" name="Deps: org.conscrypt/conscrypt-openjdk-uber:2.5.2" level="project" />
+    <orderEntry type="library" name="Deps: org.clojure/core.rrb-vector:0.1.2" level="project" />
+    <orderEntry type="library" name="Deps: prismatic/schema:1.4.1" level="project" />
+    <orderEntry type="library" name="Deps: hikari-cp:3.1.0" level="project" />
+    <orderEntry type="library" name="Deps: org.ring-clojure/ring-websocket-protocols:1.12.2" level="project" />
+    <orderEntry type="library" name="Deps: com.google.cloud/google-cloud-core:2.38.0" level="project" />
+    <orderEntry type="library" name="Deps: crypto-equality:1.0.1" level="project" />
+    <orderEntry type="library" name="Deps: funcool/promesa:10.0.594" level="project" />
+    <orderEntry type="library" name="Deps: org.checkerframework/checker-qual:3.42.0" level="project" />
+    <orderEntry type="library" name="Deps: io.grpc/grpc-core:1.62.2" level="project" />
+    <orderEntry type="library" name="Deps: net.java.dev.jna/jna:5.12.1" level="project" />
+    <orderEntry type="library" name="Deps: io.grpc/grpc-rls:1.62.2" level="project" />
+    <orderEntry type="library" name="Deps: org.eclipse.jetty/jetty-io:11.0.20" level="project" />
+    <orderEntry type="library" name="Deps: org.clojure/tools.reader:1.4.2" level="project" />
+    <orderEntry type="library" name="Deps: org.ring-clojure/ring-core-protocols:1.12.2" level="project" />
     <orderEntry type="library" name="Deps: org.tcrawley/dynapath:1.1.0" level="project" />
-    <orderEntry type="library" name="Deps: io.opencensus/opencensus-contrib-grpc-util:0.28.0" level="project" />
-    <orderEntry type="library" name="Deps: com.google.api-client/google-api-client:1.32.1" level="project" />
-    <orderEntry type="library" name="Deps: io.grpc/grpc-netty-shaded:1.39.0" level="project" />
-    <orderEntry type="library" name="Deps: org.eclipse.jetty.toolchain/jetty-servlet-api:4.0.6" level="project" />
-    <orderEntry type="library" name="Deps: com.taoensso/nippy:3.1.1" level="project" />
-    <orderEntry type="library" name="Deps: potemkin:0.4.5" level="project" />
-    <orderEntry type="library" name="Deps: info.sunng/ring-jetty9-adapter:0.17.6" level="project" />
-    <orderEntry type="library" name="Deps: io.netty/netty-resolver:4.1.67.Final" level="project" />
-    <orderEntry type="library" name="Deps: org.slf4j/slf4j-api:2.0.0-alpha6" level="project" />
-    <orderEntry type="library" name="Deps: org.ow2.asm/asm-analysis:9.2" level="project" />
-    <orderEntry type="library" name="Deps: com.sun.activation/jakarta.activation:2.0.1" level="project" />
-    <orderEntry type="library" name="Deps: com.google.cloud/proto-google-cloud-firestore-bundle-v1:2.6.1" level="project" />
-    <orderEntry type="library" name="Deps: metosin/jsonista:0.3.5" level="project" />
-    <orderEntry type="library" name="Deps: com.google.protobuf/protobuf-java:3.17.3" level="project" />
-    <orderEntry type="library" name="Deps: com.google.auth/google-auth-library-oauth2-http:0.26.0" level="project" />
-    <orderEntry type="library" name="Deps: ring/ring-servlet:1.9.5" level="project" />
+    <orderEntry type="library" name="Deps: io.opencensus/opencensus-contrib-grpc-util:0.31.1" level="project" />
+    <orderEntry type="library" name="Deps: io.grpc/grpc-xds:1.62.2" level="project" />
+    <orderEntry type="library" name="Deps: com.google.api-client/google-api-client:2.4.0" level="project" />
+    <orderEntry type="library" name="Deps: io.grpc/grpc-netty-shaded:1.62.2" level="project" />
+    <orderEntry type="library" name="Deps: com.taoensso/nippy:3.4.2" level="project" />
+    <orderEntry type="library" name="Deps: potemkin:0.4.7" level="project" />
+    <orderEntry type="library" name="Deps: info.sunng/ring-jetty9-adapter:0.22.6" level="project" />
+    <orderEntry type="library" name="Deps: io.netty/netty-resolver:4.1.109.Final" level="project" />
+    <orderEntry type="library" name="Deps: org.slf4j/slf4j-api:2.0.13" level="project" />
+    <orderEntry type="library" name="Deps: com.google.re2j/re2j:1.7" level="project" />
+    <orderEntry type="library" name="Deps: com.google.cloud/proto-google-cloud-firestore-bundle-v1:3.21.1" level="project" />
+    <orderEntry type="library" name="Deps: metosin/jsonista:0.3.9" level="project" />
+    <orderEntry type="library" name="Deps: com.google.protobuf/protobuf-java:3.25.3" level="project" />
+    <orderEntry type="library" name="Deps: com.google.auth/google-auth-library-oauth2-http:1.23.0" level="project" />
     <orderEntry type="library" name="Deps: org.clojure/core.memoize:1.0.253" level="project" />
     <orderEntry type="library" name="Deps: com.stuartsierra/dependency:1.0.0" level="project" />
     <orderEntry type="library" name="Deps: hawk:0.2.11" level="project" />
-    <orderEntry type="library" name="Deps: tech.droit/clj-diff:1.0.1" level="project" />
-    <orderEntry type="library" name="Deps: camel-snake-kebab:0.4.2" level="project" />
+    <orderEntry type="library" name="Deps: camel-snake-kebab:0.4.3" level="project" />
     <orderEntry type="library" name="Deps: clj-antlr:0.2.12" level="project" />
-    <orderEntry type="library" name="Deps: io.grpc/grpc-grpclb:1.39.0" level="project" />
+    <orderEntry type="library" name="Deps: io.grpc/grpc-grpclb:1.62.2" level="project" />
     <orderEntry type="library" name="Deps: org.clojure/data.priority-map:1.1.0" level="project" />
-    <orderEntry type="library" name="Deps: org.clojure/java.data:1.0.95" level="project" />
+    <orderEntry type="library" name="Deps: org.clojure/java.data:1.2.107" level="project" />
     <orderEntry type="library" name="Deps: org.antlr/antlr4:4.9.3" level="project" />
-    <orderEntry type="library" name="Deps: com.sun.mail/jakarta.mail:2.0.1" level="project" />
-    <orderEntry type="library" name="Deps: org.eclipse.jetty/jetty-server:10.0.9" level="project" />
-    <orderEntry type="library" name="Deps: io.opencensus/opencensus-api:0.28.0" level="project" />
-    <orderEntry type="library" name="Deps: io.grpc/grpc-auth:1.39.0" level="project" />
-    <orderEntry type="library" name="Deps: org.apache.httpcomponents/httpmime:4.5.13" level="project" />
+    <orderEntry type="library" name="Deps: org.eclipse.jetty/jetty-server:11.0.20" level="project" />
+    <orderEntry type="library" name="Deps: io.opencensus/opencensus-api:0.31.1" level="project" />
+    <orderEntry type="library" name="Deps: io.grpc/grpc-auth:1.62.2" level="project" />
+    <orderEntry type="library" name="Deps: org.apache.httpcomponents/httpmime:4.5.14" level="project" />
     <orderEntry type="library" name="Deps: com.google.code.findbugs/jsr305:3.0.2" level="project" />
-    <orderEntry type="library" name="Deps: org.apache.commons/commons-csv:1.9.0" level="project" />
-    <orderEntry type="library" name="Deps: ring/ring-core:1.9.5" level="project" />
+    <orderEntry type="library" name="Deps: org.apache.commons/commons-csv:1.11.0" level="project" />
+    <orderEntry type="library" name="Deps: ring/ring-core:1.12.2" level="project" />
     <orderEntry type="library" name="Deps: org.clojure/core.cache:1.0.225" level="project" />
     <orderEntry type="library" name="Deps: meta-merge:1.0.0" level="project" />
-    <orderEntry type="library" name="Deps: org.ow2.asm/asm-tree:9.2" level="project" />
-    <orderEntry type="library" name="Deps: com.google.api/gax:1.66.0" level="project" />
-    <orderEntry type="library" name="Deps: org.clojure/core.async:1.5.648" level="project" />
-    <orderEntry type="library" name="Deps: com.google.http-client/google-http-client-apache-v2:1.39.2" level="project" />
-    <orderEntry type="library" name="Deps: com.fasterxml.jackson.datatype/jackson-datatype-jsr310:2.13.0" level="project" />
+    <orderEntry type="library" name="Deps: org.eclipse.angus/angus-activation:2.0.2" level="project" />
+    <orderEntry type="library" name="Deps: com.google.api/gax:2.48.0" level="project" />
+    <orderEntry type="library" name="Deps: jakarta.activation/jakarta.activation-api:2.1.3" level="project" />
+    <orderEntry type="library" name="Deps: org.clojure/core.async:1.6.681" level="project" />
+    <orderEntry type="library" name="Deps: com.google.http-client/google-http-client-apache-v2:1.44.1" level="project" />
+    <orderEntry type="library" name="Deps: com.fasterxml.jackson.datatype/jackson-datatype-jsr310:2.17.1" level="project" />
     <orderEntry type="library" name="Deps: org.glassfish/javax.json:1.0.4" level="project" />
-    <orderEntry type="library" name="Deps: javax.xml.bind/jaxb-api:2.3.0" level="project" />
-    <orderEntry type="library" name="Deps: com.google.code.gson/gson:2.8.7" level="project" />
-    <orderEntry type="library" name="Deps: com.google.api.grpc/proto-google-cloud-firestore-v1:2.6.1" level="project" />
-    <orderEntry type="library" name="Deps: org.eclipse.jetty/jetty-alpn-server:10.0.9" level="project" />
+    <orderEntry type="library" name="Deps: javax.xml.bind/jaxb-api:2.4.0-b180830.0359" level="project" />
+    <orderEntry type="library" name="Deps: com.google.code.gson/gson:2.10.1" level="project" />
+    <orderEntry type="library" name="Deps: org.clj-commons/pretty:2.2.1" level="project" />
+    <orderEntry type="library" name="Deps: com.google.api.grpc/proto-google-cloud-firestore-v1:3.21.1" level="project" />
+    <orderEntry type="library" name="Deps: org.eclipse.jetty/jetty-alpn-server:11.0.20" level="project" />
   </component>
 </module>


### PR DESCRIPTION
Used `clj -M:outdated`.

Only `carmine` has breaking changes, but I think the impact will be minor.

- - -

Do you want to upgrade org.eclipse.angus/angus-mail '2.0.2' to '2.0.3' in deps.edn (y/n): y
https://eclipse-ee4j.github.io/angus-mail/docs/CHANGES.txt
No breaking changes.
  
Do you want to upgrade commons-codec/commons-codec '1.15' to '1.17.1' in deps.edn (y/n): y
https://commons.apache.org/proper/commons-codec/changes-report.html
No breaking changes.

Do you want to upgrade org.clojure/tools.logging '1.2.4' to '1.3.0' in deps.edn (y/n): y
https://github.com/clojure/tools.logging/blob/master/CHANGELOG.md
No breaking changes.

Do you want to upgrade metosin/ring-http-response '0.9.3' to '0.9.4' in deps.edn (y/n): y
https://github.com/metosin/ring-http-response/blob/master/CHANGELOG.md
No breaking changes.

Do you want to upgrade diehard/diehard '0.11.3' to '0.11.12' in deps.edn (y/n): y
https://github.com/sunng87/diehard/blob/master/CHANGELOG.md
No breaking changes.

Do you want to upgrade com.cognitect/transit-cljs '0.8.269' to '0.8.280' in deps.edn (y/n): y
https://github.com/cognitect/transit-clj/commits/master/
No breaking changes.

Do you want to upgrade com.taoensso/carmine '3.1.0' to '3.4.1' in deps.edn (y/n): y
https://github.com/taoensso/carmine/blob/master/CHANGELOG.md
**Including bracking changes.**
See details https://github.com/taoensso/carmine/wiki/0-Breaking-changes#carmine-v32x-to-v33x

Do you want to upgrade commons-io/commons-io '2.11.0' to '2.16.1' in deps.edn (y/n): y
No breacking changes.

Do you want to upgrade clj-http/clj-http '3.12.3' to '3.13.0' in deps.edn (y/n): y
https://github.com/dakrone/clj-http/commits/3.x/
No breaking changes.

Do you want to upgrade com.cognitect/transit-clj '1.0.329' to '1.0.333' in deps.edn (y/n): y
https://github.com/cognitect/transit-clj/commits/master/
No breacking changes.

Do you want to upgrade com.github.seancorfield/next.jdbc '1.2.772' to '1.3.939' in deps.edn (y/n): y
https://github.com/seancorfield/next-jdbc/blob/develop/CHANGELOG.md
No breacking changes.

Do you want to upgrade prismatic/schema '1.2.0' to '1.4.1' in deps.edn (y/n): y
https://github.com/plumatic/schema/blob/master/CHANGELOG.md
No breacking changes.

Do you want to upgrade hikari-cp/hikari-cp '2.14.0' to '3.1.0' in deps.edn (y/n): y
https://github.com/tomekw/hikari-cp/blob/master/CHANGELOG.md
https://github.com/brettwooldridge/HikariCP/blob/dev/CHANGES
No breacking changes.

Do you want to upgrade info.sunng/ring-jetty9-adapter '0.17.6' to '0.33.4' in deps.edn (y/n): y
=> But Use 0.22.6 for JDK 11
https://github.com/sunng87/ring-jetty9-adapter
https://github.com/sunng87/ring-jetty9-adapter/releases

Do you want to upgrade metosin/jsonista '0.3.5' to '0.3.9' in deps.edn (y/n): y
https://github.com/metosin/jsonista/blob/master/CHANGELOG.md
https://github.com/FasterXML/jackson/wiki/Jackson-Releases
No breacking changes.

Do you want to upgrade camel-snake-kebab/camel-snake-kebab '0.4.2' to '0.4.3' in deps.edn (y/n): y
https://github.com/clj-commons/camel-snake-kebab/commits/master/
No breacking changes.

Do you want to upgrade org.apache.commons/commons-csv '1.9.0' to '1.11.0' in deps.edn (y/n): y
https://commons.apache.org/proper/commons-csv/changes-report.html
No breacking changes.

Do you want to upgrade org.clojure/core.async '1.5.648' to '1.6.681' in deps.edn (y/n): y
https://github.com/clojure/core.async
No breacking changes.

Do you want to upgrade org.clojure/clojure '1.11.1' to '1.11.3' in deps.edn (y/n): y
No breacking chages.

↓dev dependencies↓ 
Do you want to upgrade org.postgresql/postgresql '42.3.3' to '42.7.3' in deps.edn (y/n): y
Do you want to upgrade lambdaisland/kaocha '1.66.1034' to '1.91.1392' in deps.edn (y/n): y
Do you want to upgrade com.walmartlabs/lacinia '1.2' to '1.2.2' in deps.edn (y/n): y
Do you want to upgrade superlifter/superlifter '0.1.3' to '0.1.5' in deps.edn (y/n): y
Do you want to upgrade com.google.firebase/firebase-admin '8.1.0' to '9.3.0' in deps.edn (y/n): y

↓build dependencies↓
Do you want to upgrade com.github.liquidz/build.edn '0.7.145' to '0.11.266' in deps.edn (y/n): y

↓GitHub Actions↓
Do you want to upgrade actions/checkout 'v3' to 'v4' in .github/workflows/release.yml (y/n): y
Do you want to upgrade actions/setup-java 'v3' to 'v4' in .github/workflows/release.yml (y/n): y
Do you want to upgrade actions/cache 'v3' to 'v4' in .github/workflows/release.yml (y/n): y
Do you want to upgrade actions/checkout 'v3' to 'v4' in .github/workflows/build-and-test.yml (y/n): y
Do you want to upgrade actions/setup-java 'v3' to 'v4' in .github/workflows/build-and-test.yml (y/n): y
Do you want to upgrade greglook/cljstyle '0.15.0' to '0.16.626' in .github/workflows/build-and-test.yml (y/n): y
Do you want to upgrade 0918nobita/setup-cljstyle 'v0.2.0' to 'v0.5.4' in .github/workflows/build-and-test.yml (y/n):y
Do you want to upgrade clj-kondo/clj-kondo '2022.04.25' to '2024.05.24' in .github/workflows/build-and-test.yml (y/n): y
Do you want to upgrade actions/cache 'v3' to 'v4' in .github/workflows/build-and-test.yml (y/n): y
