### PR TITLE
Add enable introspection option to gql

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change Log
 
 ## [Unreleased]
+### Breaking
+- Add `enable-introspection` option to Lacinia component. If you want to enable introspection, you need to set `enable-introspection` to `true` explicitly.
 
 ## 0.3.195
 ### Changed

--- a/src/toyokumo/commons/experimental/graphql/lacinia.clj
+++ b/src/toyokumo/commons/experimental/graphql/lacinia.clj
@@ -6,7 +6,7 @@
    [com.walmartlabs.lacinia.schema :as l.schema]
    [com.walmartlabs.lacinia.util :as l.util]))
 
-(defrecord Lacinia [sdl-path resolver compiled-schema]
+(defrecord Lacinia [sdl-path enable-introspection? resolver compiled-schema]
   component/Lifecycle
   (start [this]
     (if-let [sdl (io/resource sdl-path)]
@@ -14,7 +14,7 @@
           slurp
           l.parser.schema/parse-schema
           (l.util/inject-resolvers (:resolvers resolver))
-          l.schema/compile
+          (l.schema/compile {:enable-introspection? (boolean enable-introspection?)})
           (->> (assoc this :compiled-schema)))
       (throw (IllegalArgumentException. (str "Schema Definition Language file can not find in " sdl-path)))))
   (stop [this]


### PR DESCRIPTION
Add option to control whether schema introspection is enabled.

Graph QL introspection is convinient, but it's could be a security issue in production.

The default value is nil, which means it is disabled.

https://github.com/walmartlabs/lacinia/blob/99d71e17344577bb71f48b03aa88d22853be6277/src/com/walmartlabs/lacinia/schema.clj#L2015-L2017