### PR TITLE
Add aws dynamo db component

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,12 @@
+{
+  "runOnSave.commands": [
+    {
+      "match": ".*\\.clj[cs]?$",
+      "command": "cljstyle fix ${file}",
+      "runIn": "backend",
+      "async": true
+    }
+  ],
+  "calva.evalOnSave": true,
+  "calva.enableClojureLspOnStart": "when-file-opened-use-furthest-project"
+}

--- a/deps.edn
+++ b/deps.edn
@@ -18,7 +18,8 @@
         org.clojure/tools.logging {:mvn/version "1.3.0"}
         org.eclipse.angus/angus-mail {:mvn/version "2.0.3"}
         clj-http/clj-http {:mvn/version "3.13.0"}
-        diehard/diehard {:mvn/version "0.11.12"}}
+        diehard/diehard {:mvn/version "0.11.12"}
+        software.amazon.awssdk/dynamodb {:mvn/version "2.31.51"}}
  :aliases
  {:dev {:extra-paths ["test" "dev-resources"]
         :extra-deps {org.postgresql/postgresql {:mvn/version "42.7.3"}

--- a/src/toyokumo/commons/aws/dynamo_db/component.clj
+++ b/src/toyokumo/commons/aws/dynamo_db/component.clj
@@ -1,7 +1,9 @@
 (ns toyokumo.commons.aws.dynamo-db.component
   (:require
    [com.stuartsierra.component :as component]
-   [schema.core :as s])
+   [schema.core :as s]
+   [toyokumo.commons.aws.dynamo-db.protocol :as tc.ddb.protocol]
+   [toyokumo.commons.aws.dynamo-db.request :as tc.ddb.req])
   (:import
    (java.net
     URI)
@@ -32,4 +34,8 @@
   (stop [this]
     (when-let [client (:client this)]
       (.close client))
-    (assoc this :client nil)))
+    (assoc this :client nil))
+
+  tc.ddb.protocol/IDynamoDb
+  (get-item [this table-name partition-key]
+    (tc.ddb.req/get-item (:client this) table-name partition-key)))

--- a/src/toyokumo/commons/aws/dynamo_db/component.clj
+++ b/src/toyokumo/commons/aws/dynamo_db/component.clj
@@ -1,0 +1,35 @@
+(ns toyokumo.commons.aws.dynamo-db.component
+  (:require
+   [com.stuartsierra.component :as component]
+   [schema.core :as s])
+  (:import
+   (java.net
+    URI)
+   (software.amazon.awssdk.auth.credentials
+    AwsCredentialsProvider)
+   (software.amazon.awssdk.regions
+    Region)
+   (software.amazon.awssdk.services.dynamodb
+    DynamoDbClient)))
+
+(s/defrecord AwsDynamoDb
+  [dynamo-db-client :- DynamoDbClient
+   region :- (s/maybe Region)
+   endpoint :- (s/maybe URI)
+   credentials :- (s/maybe AwsCredentialsProvider)]
+
+  component/Lifecycle
+  (start [this]
+    (let [client (-> (DynamoDbClient/builder)
+                     (cond->
+                      region (.region region)
+                      endpoint (.endpointOverride endpoint)
+                      credentials (.credentialsProvider credentials))
+                     (.build))]
+      (println "DynamoDB client created" client)
+      (assoc this
+             :client client)))
+  (stop [this]
+    (when-let [client (:client this)]
+      (.close client))
+    (assoc this :client nil)))

--- a/src/toyokumo/commons/aws/dynamo_db/format.clj
+++ b/src/toyokumo/commons/aws/dynamo_db/format.clj
@@ -1,0 +1,16 @@
+(ns toyokumo.commons.aws.dynamo-db.format
+  (:require
+   [schema.core :as s])
+  (:import
+   (software.amazon.awssdk.services.dynamodb.model
+    AttributeValue)))
+
+(s/defn attribute-value->clj
+  "Converts an AttributeValue to a clojure data structure.
+   This function supports String, Number, Boolean, and Null types."
+  [attribute-value :- AttributeValue]
+  (cond
+    (some? (.s attribute-value)) (.s attribute-value)
+    (some? (.n attribute-value)) (Integer/parseInt (.n attribute-value))
+    (some? (.bool attribute-value)) (.bool attribute-value)
+    :else nil))

--- a/src/toyokumo/commons/aws/dynamo_db/protocol.clj
+++ b/src/toyokumo/commons/aws/dynamo_db/protocol.clj
@@ -1,0 +1,5 @@
+(ns toyokumo.commons.aws.dynamo-db.protocol)
+
+(defprotocol IDynamoDb
+  (get-item [this table-name partition-key]) ; Get item from DynamoDB table using the provided partition key
+  )

--- a/src/toyokumo/commons/aws/dynamo_db/request.clj
+++ b/src/toyokumo/commons/aws/dynamo_db/request.clj
@@ -1,0 +1,49 @@
+(ns toyokumo.commons.aws.dynamo-db.request
+  (:require
+   [schema.core :as s]
+   [toyokumo.commons.aws.dynamo-db.format :as format])
+  (:import
+   (software.amazon.awssdk.services.dynamodb
+    DynamoDbClient)
+   (software.amazon.awssdk.services.dynamodb.model
+    AttributeValue
+    GetItemRequest)))
+
+(s/defschema PartitionKeyInfo {:name s/Str
+                               :value s/Str})
+
+(s/defschema PartitionKey {s/Str AttributeValue})
+
+(s/defn ^:private create-partition-key :- {s/Str AttributeValue}
+  "Creates a partition key map for DynamoDB.
+   The key is the partition key name and the value is the attribute value."
+  [{:keys [:name :value]} :- PartitionKeyInfo]
+  {name (-> (AttributeValue/builder)
+            (.s value)
+            (.build))})
+
+(s/defschema DynamoDbItem {s/Keyword (s/maybe (s/cond-pre s/Int s/Str s/Bool))})
+
+(s/defn ^:private build-get-item-request
+  "Builds a GetItemRequest to retrieve an item from the specified table using the partition key."
+  [table-name :- s/Str
+   partition-key :- PartitionKey]
+  (-> (GetItemRequest/builder)
+      (.tableName table-name)
+      (.key partition-key)
+      (.build)))
+
+(s/defn get-item :- (s/maybe DynamoDbItem)
+  "Get item from DynamoDB table using the provided partition key.
+   Returns a map of attribute names to AttributeValue, or nil if the item does not exist."
+  [client :- DynamoDbClient
+   table-name :- s/Str
+   partition-key-info :- PartitionKeyInfo]
+  (let [partition-key (create-partition-key partition-key-info)
+        get-item-res (.getItem client
+                               (build-get-item-request table-name
+                                                       partition-key))]
+    (when (.hasItem get-item-res)
+      (-> (.item get-item-res)
+          (update-keys keyword)
+          (update-vals format/attribute-value->clj)))))

--- a/test/toyokumo/commons/aws/dynamo_db/format_test.clj
+++ b/test/toyokumo/commons/aws/dynamo_db/format_test.clj
@@ -1,0 +1,27 @@
+(ns toyokumo.commons.aws.dynamo-db.format-test
+  (:require
+   [clojure.test :refer [deftest is]]
+   [toyokumo.commons.aws.dynamo-db.format :as attribute-value->clj])
+  (:import
+   (software.amazon.awssdk.services.dynamodb.model
+    AttributeValue)))
+
+(deftest attribute-value->clj-test
+  (is (= "dummy-string"
+         (-> (AttributeValue/builder)
+             (.s "dummy-string")
+             (.build)
+             attribute-value->clj/attribute-value->clj))
+      "Converts an AttributeValue of type String to a Clojure string.")
+  (is (= 100
+         (-> (AttributeValue/builder)
+             (.n "100")
+             (.build)
+             attribute-value->clj/attribute-value->clj))
+      "Converts an AttributeValue of type Number to a Clojure integer.")
+  (is (= true
+         (-> (AttributeValue/builder)
+             (.bool true)
+             (.build)
+             attribute-value->clj/attribute-value->clj))
+      "Converts an AttributeValue of type Boolean to a Clojure boolean."))


### PR DESCRIPTION
Added component to initialize AWS DynamoDB client.

**Component initialization**

```
(component/system-map
   :dynamo-db (tc.ddb.component/map->AwsDynamoDb {:credentials (when-not (= profile :prod)
                                                       create-dev-credentials)
                                        :endpoint (when-not (= profile :prod)
                                                    (URI. development-url))
                                        :region Region/AP_NORTHEAST_1}))
```

**Getting item from DynamoDB table**

```
(let [partition-key {:name "email" :value "sample@example.com"}]
  (tc.ddb.protocol/get-item dynamo-db-component
                            "example-table"
                            partition-key))
```

The code above will return data like `{:name "Tarou" :age 20 :is-student true}`.

**Limitations**

Only string, int, bool is supported at the moment.