### PR TITLE
Add executor option to Lacinia

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change Log
 
 ## [Unreleased]
+### Added
+- Add `executors` option to Lacinia component. If you want to set custom executors, you can use this option.
 
 ## 0.3.205
 ### Added

--- a/src/toyokumo/commons/experimental/graphql/lacinia.clj
+++ b/src/toyokumo/commons/experimental/graphql/lacinia.clj
@@ -6,7 +6,7 @@
    [com.walmartlabs.lacinia.schema :as l.schema]
    [com.walmartlabs.lacinia.util :as l.util]))
 
-(defrecord Lacinia [sdl-path enable-introspection? resolver compiled-schema]
+(defrecord Lacinia [sdl-path enable-introspection? executor resolver compiled-schema]
   component/Lifecycle
   (start [this]
     (if-let [sdl (io/resource sdl-path)]
@@ -14,7 +14,8 @@
           slurp
           l.parser.schema/parse-schema
           (l.util/inject-resolvers (:resolvers resolver))
-          (l.schema/compile {:enable-introspection? (boolean enable-introspection?)})
+          (l.schema/compile (cond-> {:enable-introspection? (boolean enable-introspection?)}
+                              executor (assoc :executor executor)))
           (->> (assoc this :compiled-schema)))
       (throw (IllegalArgumentException. (str "Schema Definition Language file can not find in " sdl-path)))))
   (stop [this]


### PR DESCRIPTION

I added an option to set custom executor of lacinia.

This options was added in lacinia 1.2.
https://github.com/walmartlabs/lacinia/blob/8480fe1e12f64fc867f227d5018977b8aaf80e5f/src/com/walmartlabs/lacinia/schema.clj#L2054-L2058

### How to use
Provide the instance of `java.util.concurrent.Executor`.
When you did not specify anything, lacinia will provide `default-executor`.
https://github.com/walmartlabs/lacinia/blob/8480fe1e12f64fc867f227d5018977b8aaf80e5f/src/com/walmartlabs/lacinia/schema.clj#L59-L76

#### Example
```clj
(let [executor (Executors/newThreadPerTaskExecutor (-> (Thread/ofVirtual)
                                                       (.name "GraphQL Executor #" 1)
                                                       (.factory)))]
  (map->Lacinia (merge {:executor executor})))
```