### PR TITLE
Bump deps and java version

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -30,9 +30,9 @@ jobs:
         java-version: [11, 17, 21]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           distribution: 'zulu'
           java-version: ${{ matrix.java-version }}
@@ -53,7 +53,7 @@ jobs:
           clj-kondo --version
 
       - name: Cache dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.m2
           key: clj-cache-${{ hashFiles('**/deps.edn') }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -27,7 +27,7 @@ jobs:
 
     strategy:
       matrix:
-        java-version: [11, 17, 21]
+        java-version: [17, 21, 25]
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,11 +7,11 @@ jobs:
     runs-on: ubuntu-latest
     permissions: write-all
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           distribution: 'zulu'
           java-version: '11'
@@ -28,7 +28,7 @@ jobs:
           clojure --version
 
       - name: Cache dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.m2
           key: clj-cache-${{ hashFiles('**/deps.edn') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/setup-java@v5
         with:
           distribution: 'zulu'
-          java-version: '11'
+          java-version: '25'
           java-package: jdk
           architecture: x64
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Breaking
+- Drop Java 11 support. Supported Java versions are now 17, 21, and 25.
+
+### Changed
+- Bump dependencies.
+
 ## 0.3.209
 ### Added
 - Add `executors` option to Lacinia component. If you want to set custom executors, you can use this option.

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,18 @@
 .PHONY: docker-stop
 docker-stop:
-	cd dev-resources && docker-compose stop
+	cd dev-resources && docker compose stop
 
 .PHONY: docker-up
 docker-up: docker-stop
-	cd dev-resources && docker-compose up -d
+	cd dev-resources && docker compose up -d
 
 .PHONY: docker-down
 docker-down: docker-stop
-	cd dev-resources && docker-compose down
+	cd dev-resources && docker compose down
 
 .PHONY: docker-ps
 docker-ps:
-	cd dev-resources && docker-compose ps
+	cd dev-resources && docker compose ps
 
 .PHONY: lint
 lint:

--- a/build.edn
+++ b/build.edn
@@ -1,5 +1,5 @@
 {:lib toyokumo/toyokumo-commons
- :version "0.3.{{git/commit-count}}"
+ :version "0.4.{{git/commit-count}}"
  :description "Utility functions that are used in multiple Toyokumo products"
  :licenses [{:name "APACHE LICENSE, VERSION 2.0"
              :url "https://www.apache.org/licenses/LICENSE-2.0"}]

--- a/deps.edn
+++ b/deps.edn
@@ -1,32 +1,32 @@
 {:paths ["src" "src-cljs" "src-cljc"]
- :deps {org.clojure/clojure {:mvn/version "1.11.3"}
-        org.clojure/core.async {:mvn/version "1.6.681"}
+ :deps {org.clojure/clojure {:mvn/version "1.12.4"}
+        org.clojure/core.async {:mvn/version "1.9.865"}
         prismatic/schema {:mvn/version "1.4.1"}
         camel-snake-kebab/camel-snake-kebab {:mvn/version "0.4.3"}
-        com.cognitect/transit-clj {:mvn/version "1.0.333"}
+        com.cognitect/transit-clj {:mvn/version "1.1.357"}
         com.cognitect/transit-cljs {:mvn/version "0.8.280"}
-        commons-codec/commons-codec {:mvn/version "1.17.1"}
-        metosin/ring-http-response {:mvn/version "0.9.4"}
-        org.apache.commons/commons-csv {:mvn/version "1.11.0"}
-        commons-io/commons-io {:mvn/version "2.16.1"}
-        info.sunng/ring-jetty9-adapter {:mvn/version "0.22.6"}
-        com.stuartsierra/component {:mvn/version "1.1.0"}
-        hikari-cp/hikari-cp {:mvn/version "3.1.0" :exclusions [org.slf4j/slf4j-api]}
-        com.github.seancorfield/next.jdbc {:mvn/version "1.3.939"}
-        metosin/jsonista {:mvn/version "0.3.9"}
-        com.taoensso/carmine {:mvn/version "3.4.1"}
-        org.clojure/tools.logging {:mvn/version "1.3.0"}
-        org.eclipse.angus/angus-mail {:mvn/version "2.0.3"}
-        clj-http/clj-http {:mvn/version "3.13.0"}
-        diehard/diehard {:mvn/version "0.11.12"}}
+        commons-codec/commons-codec {:mvn/version "1.21.0"}
+        metosin/ring-http-response {:mvn/version "0.9.5"}
+        org.apache.commons/commons-csv {:mvn/version "1.14.1"}
+        commons-io/commons-io {:mvn/version "2.21.0"}
+        info.sunng/ring-jetty9-adapter {:mvn/version "0.39.3"}
+        com.stuartsierra/component {:mvn/version "1.2.0"}
+        hikari-cp/hikari-cp {:mvn/version "4.0.0" :exclusions [org.slf4j/slf4j-api]}
+        com.github.seancorfield/next.jdbc {:mvn/version "1.3.1093"}
+        metosin/jsonista {:mvn/version "1.0.0"}
+        com.taoensso/carmine {:mvn/version "3.5.0"}
+        org.clojure/tools.logging {:mvn/version "1.3.1"}
+        org.eclipse.angus/angus-mail {:mvn/version "2.0.5"}
+        clj-http/clj-http {:mvn/version "3.13.1"}
+        diehard/diehard {:mvn/version "0.12.0"}}
  :aliases
  {:dev {:extra-paths ["test" "dev-resources"]
-        :extra-deps {org.postgresql/postgresql {:mvn/version "42.7.3"}
+        :extra-deps {org.postgresql/postgresql {:mvn/version "42.7.10"}
                      lambdaisland/kaocha {:mvn/version "1.91.1392"}
                      ;; experimental
                      com.walmartlabs/lacinia {:mvn/version "1.2.2"}
-                     superlifter/superlifter {:mvn/version "0.1.5"}
-                     com.google.firebase/firebase-admin {:mvn/version "9.3.0"}}}
+                     superlifter/superlifter {:mvn/version "0.1.6"}
+                     com.google.firebase/firebase-admin {:mvn/version "9.8.0"}}}
 
   :test {:main-opts ["-m" "kaocha.runner"]}
 


### PR DESCRIPTION
Bump deps and drop java 11 support.

 `info.sunng/ring-jetty9-adapter` (0.39.3) depends Jetty 12.x. The version is require java 17+.

Other changes had no impact on the code.

changelogs by antq

- https://github.com/dakrone/clj-http/blob/3.13.1/changelog.org
- https://github.com/cognitect/transit-clj/blob/v1.1.357/CHANGES.md
- https://github.com/seancorfield/next-jdbc/blob/v1.3.1093/CHANGELOG.md
- https://github.com/firebase/firebase-admin-java/compare/v9.3.0...v9.8.0
- https://github.com/stuartsierra/component/blob/component-1.2.0/CHANGES.md
- https://github.com/ptaoussanis/carmine/blob/v3.5.0/CHANGELOG.md
- https://github.com/apache/commons-codec/compare/commons-codec-1.17.1-RC1...commons-codec-1.21.0-RC1
- https://github.com/sunng87/diehard/blob/0.12.0/CHANGELOG.md
- https://github.com/tomekw/hikari-cp/blob/4.0.0/CHANGELOG.md
- https://github.com/sunng87/ring-jetty9-adapter/compare/0.22.6...0.39.3
- https://github.com/metosin/jsonista/blob/1.0.0/CHANGELOG.md
- https://github.com/metosin/ring-http-response/blob/0.9.5/CHANGELOG.md
- https://github.com/clojure/clojure/blob/clojure-1.12.4/changes.md
- https://github.com/clojure/core.async/compare/v1.6.681...v1.9.865
- https://github.com/clojure/tools.logging/blob/v1.3.1/CHANGELOG.md
- https://github.com/pgjdbc/pgjdbc/blob/REL42.7.10/CHANGELOG.md
- https://github.com/oliyh/superlifter/compare/0.1.5...0.1.6

