### PR TITLE
feat: add graceful shutdown option to Jetty9Server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+### Added
+- Add `:graceful-shutdown` option to `toyokumo.commons.server.jetty9/Jetty9Server`.
+  When set to `{:stop-timeout-ms N}`, the server drains in-flight HTTP requests on
+  SIGTERM (rejecting new requests with 503) before stopping, waiting up to N ms.
+  If an explicit `:configurator` is also given, it takes priority and graceful
+  shutdown is not applied.
+
 ## 0.4.218
 
 ### Breaking

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,11 @@
 ## [Unreleased]
 
 ### Added
-- Add `:graceful-shutdown` option to `toyokumo.commons.server.jetty9/Jetty9Server`.
-  When set to `{:stop-timeout-ms N}`, the server drains in-flight HTTP requests on
-  SIGTERM (rejecting new requests with 503) before stopping, waiting up to N ms.
-  If an explicit `:configurator` is also given, it takes priority and graceful
+- `toyokumo.commons.server.jetty9/Jetty9Server` now performs graceful shutdown by
+  default: on SIGTERM the server drains in-flight HTTP requests (rejecting new
+  requests with 503) before stopping, waiting up to `default-stop-timeout-ms`
+  (25s). Pass `:graceful-shutdown {:stop-timeout-ms N}` to override the timeout.
+  If an explicit `:configurator` is given, it takes priority and graceful
   shutdown is not applied.
 
 ## 0.4.218

--- a/src/toyokumo/commons/server/jetty9.clj
+++ b/src/toyokumo/commons/server/jetty9.clj
@@ -51,12 +51,35 @@
       (.setHandler graceful (.getHandler server))
       (.setHandler server graceful))))
 
+(defn- build-opts
+  "Builds the opts passed to run-jetty. When :graceful-shutdown is set, converts
+  it into a configurator that installs the GracefulHandler. If an explicit
+  :configurator is also given, it takes priority and graceful shutdown is not
+  applied."
+  [{:keys [graceful-shutdown configurator] :as opts}]
+  (cond
+    (nil? graceful-shutdown)
+    opts
+
+    ;; When :configurator is given it takes priority, so graceful-shutdown is ignored.
+    configurator
+    (dissoc opts :graceful-shutdown)
+
+    :else
+    (let [{:keys [stop-timeout-ms]} graceful-shutdown]
+      (when-not (and (integer? stop-timeout-ms) (pos? stop-timeout-ms))
+        (throw (ex-info "Jetty9Server :graceful-shutdown requires a positive integer :stop-timeout-ms"
+                        {:graceful-shutdown graceful-shutdown})))
+      (-> opts
+          (dissoc :graceful-shutdown)
+          (assoc :configurator (graceful-configurator stop-timeout-ms))))))
+
 (defrecord Jetty9Server [handler opts ^Server server]
   component/Lifecycle
   (start [this]
     (if server
       this
-      (assoc this :server (jetty9/run-jetty (:handler handler) opts))))
+      (assoc this :server (jetty9/run-jetty (:handler handler) (build-opts opts)))))
   (stop [this]
     (when server
       (jetty9/stop-server server))

--- a/src/toyokumo/commons/server/jetty9.clj
+++ b/src/toyokumo/commons/server/jetty9.clj
@@ -51,22 +51,23 @@
       (.setHandler graceful (.getHandler server))
       (.setHandler server graceful))))
 
+(def default-stop-timeout-ms
+  "Default graceful shutdown stop timeout in milliseconds, used when
+  :stop-timeout-ms is not specified. Adjust per product as needed via the
+  Jetty9Server :graceful-shutdown {:stop-timeout-ms N} option, e.g. to fit the
+  deployment platform's shutdown grace period."
+  25000)
+
 (defn- build-opts
-  "Builds the opts passed to run-jetty. When :graceful-shutdown is set, converts
-  it into a configurator that installs the GracefulHandler. If an explicit
-  :configurator is also given, it takes priority and graceful shutdown is not
-  applied."
+  "Builds the opts passed to run-jetty. Graceful shutdown is enabled by default,
+  installing a GracefulHandler with default-stop-timeout-ms; pass
+  :graceful-shutdown {:stop-timeout-ms N} to override the timeout. If an explicit
+  :configurator is given, it takes priority and graceful shutdown is not applied."
   [{:keys [graceful-shutdown configurator] :as opts}]
-  (cond
-    (nil? graceful-shutdown)
-    opts
-
+  (if configurator
     ;; When :configurator is given it takes priority, so graceful-shutdown is ignored.
-    configurator
     (dissoc opts :graceful-shutdown)
-
-    :else
-    (let [{:keys [stop-timeout-ms]} graceful-shutdown]
+    (let [stop-timeout-ms (get graceful-shutdown :stop-timeout-ms default-stop-timeout-ms)]
       (when-not (and (integer? stop-timeout-ms) (pos? stop-timeout-ms))
         (throw (ex-info "Jetty9Server :graceful-shutdown requires a positive integer :stop-timeout-ms"
                         {:graceful-shutdown graceful-shutdown})))

--- a/src/toyokumo/commons/server/jetty9.clj
+++ b/src/toyokumo/commons/server/jetty9.clj
@@ -1,10 +1,55 @@
 (ns toyokumo.commons.server.jetty9
   (:require
+   [clojure.tools.logging :as log]
    [com.stuartsierra.component :as component]
    [ring.adapter.jetty9 :as jetty9])
   (:import
+   (java.util.concurrent
+    CompletableFuture)
    (org.eclipse.jetty.server
-    Server)))
+    Server)
+   (org.eclipse.jetty.server.handler
+    GracefulHandler)
+   (org.eclipse.jetty.util.component
+    LifeCycle$Listener)))
+
+(defn- logging-graceful-handler
+  "Builds a GracefulHandler that logs the start and end of the shutdown wait.
+  If the wait does not finish within the stop timeout, the future is never
+  completed, so the end log is not emitted (only the start log and the
+  server-stopped log appear)."
+  []
+  (proxy [GracefulHandler] []
+    (shutdown []
+      (log/infof "jetty graceful shutdown start. in-flight requests:%d"
+                 (.getCurrentRequestCount ^GracefulHandler this))
+      ;; whenComplete returns a new derived future, so we register the logging
+      ;; callback only and return the original future from shutdown. This keeps
+      ;; exceptions in the logging callback from affecting Jetty's shutdown
+      ;; completion check, and preserves shutdown idempotency (the same future).
+      (let [^CompletableFuture fut (proxy-super shutdown)]
+        (.whenComplete fut
+                       (fn [_ ex]
+                         (if ex
+                           (log/warn ex "jetty graceful shutdown aborted")
+                           (log/info "jetty graceful shutdown end. all in-flight requests completed"))))
+        fut))))
+
+(defn- graceful-configurator
+  "A configurator that waits for in-flight requests to complete before stopping
+  Jetty on SIGTERM. Inserting a GracefulHandler at the head of the handler chain
+  makes the server respond with 503 to new requests once shutdown begins, while
+  waiting for in-flight requests to complete up to stop-timeout-ms."
+  [stop-timeout-ms]
+  (fn [^Server server]
+    (.setStopTimeout server (long stop-timeout-ms))
+    (.addEventListener server
+                       (reify LifeCycle$Listener
+                         (lifeCycleStopped [_ _]
+                           (log/info "jetty server stopped"))))
+    (let [^GracefulHandler graceful (logging-graceful-handler)]
+      (.setHandler graceful (.getHandler server))
+      (.setHandler server graceful))))
 
 (defrecord Jetty9Server [handler opts ^Server server]
   component/Lifecycle

--- a/test/toyokumo/commons/server/jetty9_test.clj
+++ b/test/toyokumo/commons/server/jetty9_test.clj
@@ -119,3 +119,16 @@
           ;; Always release the request and stop the server, even on assertion failure.
           (deliver release true)
           (jetty9/stop-server server))))))
+
+(deftest build-opts-test
+  (testing "throws when :graceful-shutdown has no valid :stop-timeout-ms"
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo
+         #"stop-timeout-ms"
+          (#'sut/build-opts {:graceful-shutdown {}}))))
+  (testing "an explicit :configurator takes priority and :graceful-shutdown is dropped"
+    (let [user-configurator (fn [_server] nil)
+          result (#'sut/build-opts {:configurator user-configurator
+                                    :graceful-shutdown {:stop-timeout-ms 5000}})]
+      (is (identical? user-configurator (:configurator result)))
+      (is (not (contains? result :graceful-shutdown))))))

--- a/test/toyokumo/commons/server/jetty9_test.clj
+++ b/test/toyokumo/commons/server/jetty9_test.clj
@@ -121,11 +121,15 @@
           (jetty9/stop-server server))))))
 
 (deftest build-opts-test
-  (testing "throws when :graceful-shutdown has no valid :stop-timeout-ms"
+  (testing "graceful shutdown is enabled by default (a configurator is installed)"
+    (let [result (#'sut/build-opts {})]
+      (is (fn? (:configurator result)))
+      (is (not (contains? result :graceful-shutdown)))))
+  (testing "throws when an explicit :stop-timeout-ms is not a positive integer"
     (is (thrown-with-msg?
          clojure.lang.ExceptionInfo
          #"stop-timeout-ms"
-          (#'sut/build-opts {:graceful-shutdown {}}))))
+          (#'sut/build-opts {:graceful-shutdown {:stop-timeout-ms 0}}))))
   (testing "an explicit :configurator takes priority and :graceful-shutdown is dropped"
     (let [user-configurator (fn [_server] nil)
           result (#'sut/build-opts {:configurator user-configurator

--- a/test/toyokumo/commons/server/jetty9_test.clj
+++ b/test/toyokumo/commons/server/jetty9_test.clj
@@ -2,9 +2,20 @@
   (:require
    [clj-http.client :as client]
    [clojure.test :refer :all]
+   [clojure.tools.logging.test :as tlt]
    [com.stuartsierra.component :as component]
+   [ring.adapter.jetty9 :as jetty9]
    [toyokumo.commons.ring.response :as res]
-   [toyokumo.commons.server.jetty9 :refer [map->Jetty9Server]]))
+   [toyokumo.commons.server.jetty9 :as sut :refer [map->Jetty9Server]])
+  (:import
+   (java.util.concurrent
+    CompletableFuture
+    TimeUnit)
+   (org.eclipse.jetty.server
+    Server)
+   (org.eclipse.jetty.server.handler
+    DefaultHandler
+    GracefulHandler)))
 
 (defrecord TestHandler [handler])
 
@@ -30,3 +41,81 @@
         (finally
           (let [server (component/stop server)]
             (is (nil? (:server server)))))))))
+
+(deftest logging-graceful-handler-test
+  (testing "calling shutdown emits the start-wait log and returns a future"
+    (tlt/with-log
+      (let [handler (#'sut/logging-graceful-handler)
+            fut (.shutdown ^GracefulHandler handler)]
+        (is (instance? CompletableFuture fut))
+        (is (tlt/logged? 'toyokumo.commons.server.jetty9 :info
+                         #"graceful shutdown start\. in-flight requests:\d+")))))
+  (testing "with no in-flight requests the future completes immediately and the end-wait log is emitted"
+    (tlt/with-log
+      (let [handler (#'sut/logging-graceful-handler)
+            fut (.shutdown ^GracefulHandler handler)]
+        (.get ^CompletableFuture fut 1 TimeUnit/SECONDS)
+        (is (tlt/logged? 'toyokumo.commons.server.jetty9 :info
+                         #"graceful shutdown end\. all in-flight requests completed"))))))
+
+(deftest graceful-configurator-test
+  (testing "sets the stop timeout and inserts a GracefulHandler at the head of the handler chain"
+    (let [server (Server.)
+          original-handler (DefaultHandler.)
+          stop-timeout-ms 12345]
+      (.setHandler server original-handler)
+      ((#'sut/graceful-configurator stop-timeout-ms) server)
+      (is (= stop-timeout-ms (.getStopTimeout server)))
+      (let [handler (.getHandler server)]
+        (is (instance? GracefulHandler handler))
+        (is (identical? original-handler
+                        (.getHandler ^GracefulHandler handler))))))
+  (testing "emits the server-stopped log after the server stops"
+    (tlt/with-log
+      (let [server (Server.)]
+        (.setHandler server (DefaultHandler.))
+        ((#'sut/graceful-configurator 1000) server)
+        (.start server)
+        (.stop server))
+      (is (tlt/logged? 'toyokumo.commons.server.jetty9 :info
+                       #"jetty server stopped"))))
+  (testing "stop blocks until the in-flight request drains"
+    (let [started (promise)
+          release (promise)
+          server (jetty9/run-jetty
+                  (fn [_]
+                    (deliver started true)
+                    @release
+                    (res/ok "done"))
+                  {:host "127.0.0.1"
+                   :port 9998
+                   :join? false
+                   :configurator (#'sut/graceful-configurator 10000)})
+          resp (future (client/get "http://127.0.0.1:9998/slow"
+                                   {:throw-exceptions false
+                                    :connection-timeout 5000
+                                    :socket-timeout 10000}))]
+      (try
+        ;; Wait until the request is actually being processed (in-flight).
+        (is (true? (deref started 5000 ::timeout))
+            "the request must start being processed")
+        ;; Start stop on another thread. While an in-flight request remains, it blocks to drain.
+        (let [stop-fut (future (jetty9/stop-server server))]
+          ;; Without a GracefulHandler stop would complete immediately, so it being
+          ;; incomplete here proves draining.
+          (Thread/sleep 500)
+          (is (not (realized? stop-fut))
+              "stop must not complete while an in-flight request remains")
+          ;; Release the in-flight request so it can complete.
+          (deliver release true)
+          ;; The in-flight request completes with 200 without being interrupted.
+          (let [response (deref resp 10000 ::timeout)]
+            (is (not= ::timeout response) "the request must complete")
+            (is (= 200 (:status response))))
+          ;; Draining done, so stop must complete.
+          (is (not= ::timeout (deref stop-fut 10000 ::timeout))
+              "stop must complete after the in-flight request drains"))
+        (finally
+          ;; Always release the request and stop the server, even on assertion failure.
+          (deliver release true)
+          (jetty9/stop-server server))))))


### PR DESCRIPTION
### What was done

Added a graceful shutdown option to the `Jetty9Server` component.

### Why this approach, and why it solves the problem

On SIGTERM the server now stops accepting new requests — responding with 503 — and waits for in-flight HTTP requests to finish before shutting down, so requests are no longer dropped during deploys or restarts.

It is provided as an option on the existing server component, so the behavior is unchanged when the option is omitted and backward compatibility is preserved. The wait-time limit is a required argument with no default, since the appropriate value differs per product.

When the caller supplies its own configurator, that takes priority, avoiding any unintended override of the caller's setup.

### How to read this change

Please review commit by commit.

- The graceful shutdown behavior itself (draining and logging) is guaranteed by the first commit that adds the handler.
- The second commit, which applies the option, is scoped to assembling the options and the priority decision.

### Other

Attached is a screenshot of the Jetty logs confirming that graceful shutdown actually runs when the library is used.

<img width="1368" height="251" alt="Screenshot 2026-06-18 at 14 42 04" src="https://github.com/user-attachments/assets/50b4519b-b654-4586-a1a1-51b2492e4d16" />

### 日本語

<details>
<summary>日本語</summary>

### 具体的に何をしたのか

`Jetty9Server` コンポーネントにグレースフルシャットダウンのオプションを追加した。

### なぜこの変更方法を選択したのか、なぜこの変更で課題が解決するのか

SIGTERM 受信時に、サーバーが新規リクエストの受付を停止(503 を返却)し、処理中の HTTP リクエストの完了を待ってから停止するようにした。これにより、デプロイや再起動の際に処理中のリクエストが切り捨てられなくなる。

既存のサーバーコンポーネントにオプションを追加する形にしたことで、未指定時は従来どおりの挙動を保ち、後方互換を壊さない。待機時間の上限はプロダクトごとに適切な値が異なるため必須の引数とし、デフォルトは設けていない。

また、利用側が独自の設定を渡している場合はそちらを優先することで、意図しない挙動の上書きを避けている。

### どうやってこの変更を読めばいいのか

コミットごとにお願いします。

- グレースフルシャットダウンの挙動(ドレイン・ログ出力)自体は、ハンドラを追加する最初のコミットで担保している
- オプションを適用する2つ目のコミットは、設定の組み立てと優先順位の判断ロジックに責務を限定している

### その他

ライブラリを利用した際に、グレースフルシャットダウンが実際に動作していることを確認した Jetty ログのスクリーンショットを添付する。

<img width="1368" height="251" alt="Screenshot 2026-06-18 at 14 42 04" src="https://github.com/user-attachments/assets/50b4519b-b654-4586-a1a1-51b2492e4d16" />

</details>

---

### Update: graceful shutdown is now enabled by default

Graceful shutdown is now **enabled by default** rather than opt-in. On SIGTERM the server drains in-flight requests using a default stop timeout of 25s (`default-stop-timeout-ms`). Pass `:graceful-shutdown {:stop-timeout-ms N}` to override the timeout per product, and an explicit `:configurator` still takes priority and bypasses graceful shutdown. (Added in the latest commits.)

<details>
<summary>日本語</summary>

グレースフルシャットダウンを opt-in から**デフォルト有効**に変更した。SIGTERM 時に既定 stop timeout 25s(`default-stop-timeout-ms`)で in-flight リクエストをドレインする。`:graceful-shutdown {:stop-timeout-ms N}` でプロダクトごとに timeout を上書きでき、`:configurator` を明示した場合は従来どおり優先されてバイパスされる。(直近のコミットで追加)

</details>


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215749975592854